### PR TITLE
add method to capture NSError

### DIFF
--- a/SentrySwift.xcodeproj/project.pbxproj
+++ b/SentrySwift.xcodeproj/project.pbxproj
@@ -81,6 +81,9 @@
 		9B02CAFE1CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
 		9B02CAFF1CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
 		9B02CB001CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
+		8092F8E51CF2499600634F3F /* Sentry+NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+NSError.swift */; };
+		8092F8E91CF2594100634F3F /* Sentry+NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+NSError.swift */; };
+		8092F8EA1CF2594100634F3F /* Sentry+NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+NSError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -224,6 +227,7 @@
 		9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
 		9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Extras.swift"; sourceTree = "<group>"; };
 		9B02CAFD1CF607A5004F614C /* Exception.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exception.swift; sourceTree = "<group>"; };
+		8092F8E41CF2499600634F3F /* Sentry+NSError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sentry+NSError.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -318,6 +322,7 @@
 				9B02CAB11CF5C1E8004F614C /* Extensions */,
 				036378281C225D5200644C01 /* SentrySwift.h */,
 				0363782B1C225D8300644C01 /* Sentry.swift */,
+				8092F8E41CF2499600634F3F /* Sentry+NSError.swift */,
 				03E3D1F71C3E1A2800F00547 /* DSN.swift */,
 				03E3D21E1C3EB20F00F00547 /* Request.swift */,
 				037061821C76154D0082CCCE /* Event */,
@@ -772,6 +777,7 @@
 				9B02CAB91CF5C20F004F614C /* Dictionary+Extras.swift in Sources */,
 				03C715271CE4DB910080AE60 /* Event.swift in Sources */,
 				03C715241CE4DB8D0080AE60 /* Sentry.swift in Sources */,
+				8092F8EA1CF2594100634F3F /* Sentry+NSError.swift in Sources */,
 				03C7152A1CE4DB910080AE60 /* EventSerializable.swift in Sources */,
 				03C7152E1CE4DB940080AE60 /* BreadcrumbStore.swift in Sources */,
 				9B02CABE1CF5C270004F614C /* NSDate+Extras.swift in Sources */,
@@ -803,6 +809,7 @@
 			files = (
 				03A89AA11CAACA6F00D94E22 /* BreadcrumbStore.swift in Sources */,
 				03CFCEC31C612F5300999EB7 /* CrashHandler.swift in Sources */,
+				8092F8E51CF2499600634F3F /* Sentry+NSError.swift in Sources */,
 				03E3D21F1C3EB20F00F00547 /* Request.swift in Sources */,
 				0363782C1C225D8300644C01 /* Sentry.swift in Sources */,
 				03D4D9F91CA48FA800799CC9 /* Breadcrumb.swift in Sources */,
@@ -840,6 +847,7 @@
 				9B02CAB81CF5C20F004F614C /* Dictionary+Extras.swift in Sources */,
 				033A342A1C605B7E00BED5AE /* EventProperties.swift in Sources */,
 				03E3D2201C3EB20F00F00547 /* Request.swift in Sources */,
+				8092F8E91CF2594100634F3F /* Sentry+NSError.swift in Sources */,
 				0363782D1C225D8300644C01 /* Sentry.swift in Sources */,
 				03CFCEC21C612F3E00999EB7 /* KSCrashHandler.swift in Sources */,
 				9B02CABD1CF5C270004F614C /* NSDate+Extras.swift in Sources */,

--- a/SentrySwift.xcodeproj/project.pbxproj
+++ b/SentrySwift.xcodeproj/project.pbxproj
@@ -81,6 +81,9 @@
 		9B02CAFE1CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
 		9B02CAFF1CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
 		9B02CB001CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
+		80628F071CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */; };
+		80628F081CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */; };
+		80628F091CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */; };
 		8092F8E51CF2499600634F3F /* Sentry+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+Error.swift */; };
 		8092F8E91CF2594100634F3F /* Sentry+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+Error.swift */; };
 		8092F8EA1CF2594100634F3F /* Sentry+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+Error.swift */; };
@@ -227,6 +230,7 @@
 		9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
 		9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Extras.swift"; sourceTree = "<group>"; };
 		9B02CAFD1CF607A5004F614C /* Exception.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exception.swift; sourceTree = "<group>"; };
+		80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentrySwiftSourceLocationTests.swift; sourceTree = "<group>"; };
 		8092F8E41CF2499600634F3F /* Sentry+Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sentry+Error.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -308,6 +312,7 @@
 				035242961C988D2F00A65D6D /* SentrySwiftCrashTests.swift */,
 				035242971C988D2F00A65D6D /* SentrySwiftTests.swift */,
 				03D4D9FF1CA586EF00799CC9 /* SentrySwiftBreadcrumbTests.swift */,
+				80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */,
 				035C4E6B1CA044060082B5EA /* SentrySwiftObjCTests.h */,
 				035C4E6C1CA044060082B5EA /* SentrySwiftObjCTests.m */,
 				035C4E6A1CA044060082B5EA /* SentrySwiftTests-Bridging-Header.h */,
@@ -799,6 +804,7 @@
 				03FF07C71CE545D300BA980E /* SentrySwiftBreadcrumbTests.swift in Sources */,
 				43FF9A3F1D12127E000B0F9A /* SentryClientTests.swift in Sources */,
 				03FF07C61CE545D300BA980E /* SentrySwiftTests.swift in Sources */,
+				80628F091CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */,
 				03FF07C51CE545D300BA980E /* SentrySwiftCrashTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -834,6 +840,7 @@
 				03D4DA001CA586EF00799CC9 /* SentrySwiftBreadcrumbTests.swift in Sources */,
 				43FF9A3D1D12127E000B0F9A /* SentryClientTests.swift in Sources */,
 				035242A91C98957C00A65D6D /* SentrySwiftTests.swift in Sources */,
+				80628F071CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */,
 				035242A81C98957800A65D6D /* SentrySwiftCrashTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -868,6 +875,7 @@
 			files = (
 				035242AA1C98957C00A65D6D /* SentrySwiftTests.swift in Sources */,
 				035242A61C9892A700A65D6D /* SentrySwiftCrashTests.swift in Sources */,
+				80628F081CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */,
 				03D4DA011CA586EF00799CC9 /* SentrySwiftBreadcrumbTests.swift in Sources */,
 				035C4E711CA044A10082B5EA /* SentrySwiftObjCTests.m in Sources */,
 				43FF9A3E1D12127E000B0F9A /* SentryClientTests.swift in Sources */,

--- a/SentrySwift.xcodeproj/project.pbxproj
+++ b/SentrySwift.xcodeproj/project.pbxproj
@@ -81,9 +81,9 @@
 		9B02CAFE1CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
 		9B02CAFF1CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
 		9B02CB001CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
-		8092F8E51CF2499600634F3F /* Sentry+NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+NSError.swift */; };
-		8092F8E91CF2594100634F3F /* Sentry+NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+NSError.swift */; };
-		8092F8EA1CF2594100634F3F /* Sentry+NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+NSError.swift */; };
+		8092F8E51CF2499600634F3F /* Sentry+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+Error.swift */; };
+		8092F8E91CF2594100634F3F /* Sentry+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+Error.swift */; };
+		8092F8EA1CF2594100634F3F /* Sentry+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+Error.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -227,7 +227,7 @@
 		9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
 		9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Extras.swift"; sourceTree = "<group>"; };
 		9B02CAFD1CF607A5004F614C /* Exception.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exception.swift; sourceTree = "<group>"; };
-		8092F8E41CF2499600634F3F /* Sentry+NSError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sentry+NSError.swift"; sourceTree = "<group>"; };
+		8092F8E41CF2499600634F3F /* Sentry+Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sentry+Error.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -322,7 +322,7 @@
 				9B02CAB11CF5C1E8004F614C /* Extensions */,
 				036378281C225D5200644C01 /* SentrySwift.h */,
 				0363782B1C225D8300644C01 /* Sentry.swift */,
-				8092F8E41CF2499600634F3F /* Sentry+NSError.swift */,
+				8092F8E41CF2499600634F3F /* Sentry+Error.swift */,
 				03E3D1F71C3E1A2800F00547 /* DSN.swift */,
 				03E3D21E1C3EB20F00F00547 /* Request.swift */,
 				037061821C76154D0082CCCE /* Event */,
@@ -777,7 +777,7 @@
 				9B02CAB91CF5C20F004F614C /* Dictionary+Extras.swift in Sources */,
 				03C715271CE4DB910080AE60 /* Event.swift in Sources */,
 				03C715241CE4DB8D0080AE60 /* Sentry.swift in Sources */,
-				8092F8EA1CF2594100634F3F /* Sentry+NSError.swift in Sources */,
+				8092F8EA1CF2594100634F3F /* Sentry+Error.swift in Sources */,
 				03C7152A1CE4DB910080AE60 /* EventSerializable.swift in Sources */,
 				03C7152E1CE4DB940080AE60 /* BreadcrumbStore.swift in Sources */,
 				9B02CABE1CF5C270004F614C /* NSDate+Extras.swift in Sources */,
@@ -809,7 +809,7 @@
 			files = (
 				03A89AA11CAACA6F00D94E22 /* BreadcrumbStore.swift in Sources */,
 				03CFCEC31C612F5300999EB7 /* CrashHandler.swift in Sources */,
-				8092F8E51CF2499600634F3F /* Sentry+NSError.swift in Sources */,
+				8092F8E51CF2499600634F3F /* Sentry+Error.swift in Sources */,
 				03E3D21F1C3EB20F00F00547 /* Request.swift in Sources */,
 				0363782C1C225D8300644C01 /* Sentry.swift in Sources */,
 				03D4D9F91CA48FA800799CC9 /* Breadcrumb.swift in Sources */,
@@ -847,7 +847,7 @@
 				9B02CAB81CF5C20F004F614C /* Dictionary+Extras.swift in Sources */,
 				033A342A1C605B7E00BED5AE /* EventProperties.swift in Sources */,
 				03E3D2201C3EB20F00F00547 /* Request.swift in Sources */,
-				8092F8E91CF2594100634F3F /* Sentry+NSError.swift in Sources */,
+				8092F8E91CF2594100634F3F /* Sentry+Error.swift in Sources */,
 				0363782D1C225D8300644C01 /* Sentry.swift in Sources */,
 				03CFCEC21C612F3E00999EB7 /* KSCrashHandler.swift in Sources */,
 				9B02CABD1CF5C270004F614C /* NSDate+Extras.swift in Sources */,

--- a/SentrySwift.xcodeproj/project.pbxproj
+++ b/SentrySwift.xcodeproj/project.pbxproj
@@ -84,6 +84,9 @@
 		80628F071CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */; };
 		80628F081CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */; };
 		80628F091CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */; };
+		80628F0B1CF544C8002A656D /* SentrySwiftErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80628F0A1CF544C8002A656D /* SentrySwiftErrorTests.swift */; };
+		80628F0C1CF544C8002A656D /* SentrySwiftErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80628F0A1CF544C8002A656D /* SentrySwiftErrorTests.swift */; };
+		80628F0D1CF544C8002A656D /* SentrySwiftErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80628F0A1CF544C8002A656D /* SentrySwiftErrorTests.swift */; };
 		8092F8E51CF2499600634F3F /* Sentry+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+Error.swift */; };
 		8092F8E91CF2594100634F3F /* Sentry+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+Error.swift */; };
 		8092F8EA1CF2594100634F3F /* Sentry+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8092F8E41CF2499600634F3F /* Sentry+Error.swift */; };
@@ -231,6 +234,7 @@
 		9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Extras.swift"; sourceTree = "<group>"; };
 		9B02CAFD1CF607A5004F614C /* Exception.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exception.swift; sourceTree = "<group>"; };
 		80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentrySwiftSourceLocationTests.swift; sourceTree = "<group>"; };
+		80628F0A1CF544C8002A656D /* SentrySwiftErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentrySwiftErrorTests.swift; sourceTree = "<group>"; };
 		8092F8E41CF2499600634F3F /* Sentry+Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sentry+Error.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -313,6 +317,7 @@
 				035242971C988D2F00A65D6D /* SentrySwiftTests.swift */,
 				03D4D9FF1CA586EF00799CC9 /* SentrySwiftBreadcrumbTests.swift */,
 				80628F061CF5417A002A656D /* SentrySwiftSourceLocationTests.swift */,
+				80628F0A1CF544C8002A656D /* SentrySwiftErrorTests.swift */,
 				035C4E6B1CA044060082B5EA /* SentrySwiftObjCTests.h */,
 				035C4E6C1CA044060082B5EA /* SentrySwiftObjCTests.m */,
 				035C4E6A1CA044060082B5EA /* SentrySwiftTests-Bridging-Header.h */,
@@ -805,6 +810,7 @@
 				43FF9A3F1D12127E000B0F9A /* SentryClientTests.swift in Sources */,
 				03FF07C61CE545D300BA980E /* SentrySwiftTests.swift in Sources */,
 				80628F091CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */,
+				80628F0D1CF544C8002A656D /* SentrySwiftErrorTests.swift in Sources */,
 				03FF07C51CE545D300BA980E /* SentrySwiftCrashTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -841,6 +847,7 @@
 				43FF9A3D1D12127E000B0F9A /* SentryClientTests.swift in Sources */,
 				035242A91C98957C00A65D6D /* SentrySwiftTests.swift in Sources */,
 				80628F071CF5417A002A656D /* SentrySwiftSourceLocationTests.swift in Sources */,
+				80628F0B1CF544C8002A656D /* SentrySwiftErrorTests.swift in Sources */,
 				035242A81C98957800A65D6D /* SentrySwiftCrashTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -879,6 +886,7 @@
 				03D4DA011CA586EF00799CC9 /* SentrySwiftBreadcrumbTests.swift in Sources */,
 				035C4E711CA044A10082B5EA /* SentrySwiftObjCTests.m in Sources */,
 				43FF9A3E1D12127E000B0F9A /* SentryClientTests.swift in Sources */,
+				80628F0C1CF544C8002A656D /* SentrySwiftErrorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SentrySwiftTests/SentrySwiftErrorTests.swift
+++ b/SentrySwiftTests/SentrySwiftErrorTests.swift
@@ -25,6 +25,7 @@ class SentrySwiftErrorTests: XCTestCase {
         assert((event.extra!["user_info"] as! [String: AnyObject]) == [:])
         assert(event.culprit == location.culprit)
         assert(event.stackTrace! == location.stackTrace)
+        assert(event.exception! == [Exception(type: error.domain, value: "\(error.domain) (\(error.code))")])
     }
 
     func testErrorWithUserInfo() {

--- a/SentrySwiftTests/SentrySwiftErrorTests.swift
+++ b/SentrySwiftTests/SentrySwiftErrorTests.swift
@@ -1,0 +1,53 @@
+//
+//  SentrySwiftErrorTests.swift
+//  SentrySwift
+//
+//  Created by Lukas Stabe on 25.05.16.
+//
+//
+
+import XCTest
+@testable import SentrySwift
+
+class SentrySwiftErrorTests: XCTestCase {
+    let client = SentryClient(dsnString: "https://username:password@app.getsentry.com/12345")!
+    let location = SentryClient.SourceLocation(file: "a", line: 1, function: "b")
+
+    func testSimpleError() {
+        let domain = "testDomain"
+        let code = 123
+        let error = NSError(domain: domain, code: code, userInfo: nil)
+
+        let event = client.eventFor(error: error, location: location)
+
+        assert(event.message == "\(domain).\(code) in \(location.culprit)")
+        assert(event.extra!["user_info"] is [String: AnyObject])
+        assert((event.extra!["user_info"] as! [String: AnyObject]) == [:])
+        assert(event.culprit == location.culprit)
+        assert(event.stackTrace! == location.stackTrace)
+    }
+
+    func testErrorWithUserInfo() {
+        let domain = "testDomain"
+        let code = 123
+        let userInfo = [
+            NSLocalizedDescriptionKey: "I am error",
+            NSUnderlyingErrorKey: NSError(domain: "foo", code: -42, userInfo: nil),
+            "some key": [NSURL(string: "https://example.com")!, 10]
+        ]
+        let error = NSError(domain: domain, code: code, userInfo: userInfo)
+
+        let event = client.eventFor(error: error, location: location)
+
+        let expectedUserInfo = [
+            NSLocalizedDescriptionKey: "I am error",
+            NSUnderlyingErrorKey: [
+                "domain": "foo",
+                "code": -42,
+                "user_info": [:]
+            ],
+            "some key": ["https://example.com", 10]
+        ]
+        assert((event.extra!["user_info"] as! [String: AnyObject]) == expectedUserInfo)
+    }
+}

--- a/SentrySwiftTests/SentrySwiftErrorTests.swift
+++ b/SentrySwiftTests/SentrySwiftErrorTests.swift
@@ -21,8 +21,8 @@ class SentrySwiftErrorTests: XCTestCase {
         let event = client.eventFor(error: error, location: location)
 
         assert(event.message == "\(domain).\(code) in \(location.culprit)")
-        assert(event.extra!["user_info"] is [String: AnyObject])
-        assert((event.extra!["user_info"] as! [String: AnyObject]) == [:])
+        assert(event.extra["user_info"] is [String: AnyObject])
+        assert((event.extra["user_info"] as! [String: AnyObject]) == [:])
         assert(event.culprit == location.culprit)
         assert(event.stackTrace! == location.stackTrace)
         assert(event.exception! == [Exception(type: error.domain, value: "\(error.domain) (\(error.code))")])
@@ -49,6 +49,6 @@ class SentrySwiftErrorTests: XCTestCase {
             ],
             "some key": ["https://example.com", 10]
         ]
-        assert((event.extra!["user_info"] as! [String: AnyObject]) == expectedUserInfo)
+        assert((event.extra["user_info"] as! [String: AnyObject]) == expectedUserInfo)
     }
 }

--- a/SentrySwiftTests/SentrySwiftSourceLocationTests.swift
+++ b/SentrySwiftTests/SentrySwiftSourceLocationTests.swift
@@ -1,0 +1,45 @@
+//
+//  SentrySwiftSourceLocationTests.swift
+//  SentrySwift
+//
+//  Created by Lukas Stabe on 25.05.16.
+//
+//
+
+import XCTest
+@testable import SentrySwift
+
+class SentrySwiftSourceLocationTests: XCTestCase {
+
+    let loc = SentryClient.SourceLocation(file: "please", line: 7357, function: "this")
+
+    func testCulprit() {
+        assert(loc.culprit == "please:7357 this")
+    }
+
+    func testStacktrace() {
+        let expectedTrace = [
+            "frames": [
+                [
+                    "filename": "please",
+                    "lineno": 7357,
+                    "function": "this",
+                ]
+            ]
+        ]
+        assert(loc.stackTrace == expectedTrace)
+    }
+
+    func testTruncatesPath() {
+        let loc = SentryClient.SourceLocation(file: "/absolute/path/to/something.spl", line: 1, function: "a")
+        assert(loc.culprit == "something.spl:1 a")
+    }
+
+    func testSourceLocationMerge() {
+        let event = Event("hi there")
+        event.mergeSourceLocation(loc)
+        assert(event.culprit == loc.culprit)
+        assert(event.stackTrace! == loc.stackTrace)
+    }
+
+}

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -65,6 +65,9 @@ public typealias EventFingerprint = [String]
 	public var appleCrashReport: AppleCrashReport?
 	internal var breadcrumbsSerialized: BreadcrumbStore.SerializedType?
 
+    // for internal use for now, must be convertible using NSJSONSerialization
+    var stackTrace: [String: AnyObject]?
+	
 	/*
 	Creates an event
 	- Parameter message: A message
@@ -194,7 +197,8 @@ extension Event: EventSerializable {
 			("user", user?.serialized),
 			("exception", [:].set("values", value: exception?.map() { $0.serialized }.flatMap() { $0 })),
 			("applecrashreport", appleCrashReport?.serialized),
-			("breadcrumbs", breadcrumbsSerialized)
+			("breadcrumbs", breadcrumbsSerialized),
+			("stacktrace", stackTrace),
 		]
 
 		var ret: [String: AnyObject] = [:]

--- a/Sources/Exception.swift
+++ b/Sources/Exception.swift
@@ -22,6 +22,12 @@ import Foundation
 
         super.init()
     }
+
+    public override func isEqual(object: AnyObject?) -> Bool {
+        let lhs = self
+        guard let rhs = object as? Exception else { return false }
+        return lhs.type == rhs.type && lhs.value == rhs.value && lhs.module == rhs.module
+    }
 }
 
 extension Exception: EventSerializable {

--- a/Sources/Sentry+Error.swift
+++ b/Sources/Sentry+Error.swift
@@ -63,6 +63,8 @@ extension SentryClient {
             SentryLog.Error.log("Failed to capture errors userInfo, since it contained non-string keys: \(error)")
         }
 
+        event.exception = [Exception(type: error.domain, value: "\(error.domain) (\(error.code))")]
+
         return event
     }
 

--- a/Sources/Sentry+NSError.swift
+++ b/Sources/Sentry+NSError.swift
@@ -25,6 +25,13 @@ private func cleanValue(v: AnyObject) -> AnyObject? {
     case let v as NSURL:
         return v.absoluteString
 
+    case let v as NSError:
+        return [
+            "domain": v.domain,
+            "code": v.code,
+            "user_info": cleanValue(v.userInfo)!
+        ]
+
     default:
         return nil
     }

--- a/Sources/Sentry+NSError.swift
+++ b/Sources/Sentry+NSError.swift
@@ -1,0 +1,58 @@
+//
+//  Sentry+NSError.swift
+//  SentrySwift
+//
+//  Created by Lukas Stabe on 22.05.16.
+//
+//
+
+import Foundation
+
+
+private func cleanValue(v: AnyObject) -> AnyObject? {
+    switch v {
+    case is NSNumber: fallthrough
+    case is NSString: fallthrough
+    case is NSNull:
+        return v
+
+    case let v as [String: AnyObject]:
+        return cleanDict(v)
+
+    case let v as [AnyObject]:
+        return v.flatMap(cleanValue)
+
+    case let v as NSURL:
+        return v.absoluteString
+
+    default:
+        return nil
+    }
+}
+
+private func cleanDict(d: [String: AnyObject]) -> [String: AnyObject] {
+    var ret = [String: AnyObject]()
+
+    for (k, v) in d {
+        guard let c = cleanValue(v) else { continue }
+        ret[k] = c
+    }
+
+    return ret
+}
+
+extension SentryClient {
+
+    public func captureError(error: NSError, function: String = #function, file: String = #file, line: Int = #line) {
+        let culprit = "\((file as NSString).lastPathComponent):\(line) \(function)"
+        let message = "\(error.domain).\(error.code) in \(culprit)"
+
+        let event = Event.build(message) {
+            $0.level = .Error
+            $0.culprit = culprit
+            $0.extra = ["user_info": cleanValue(error.userInfo as! [String: AnyObject])!]
+        }
+
+        captureEvent(event)
+    }
+}

--- a/Sources/Sentry+NSError.swift
+++ b/Sources/Sentry+NSError.swift
@@ -33,7 +33,7 @@ private func cleanValue(v: AnyObject) -> AnyObject? {
         ]
 
     default:
-        return nil
+        return "\(v)"
     }
 }
 

--- a/Sources/Sentry.swift
+++ b/Sources/Sentry.swift
@@ -152,3 +152,34 @@ import Foundation
 		}
 	}
 }
+
+extension SentryClient {
+
+    // internal struct to capture file, line and function number
+    struct SourceLocation {
+        let file: String
+        let line: Int
+        let function: String
+
+        var fileName: String {
+            return (file as NSString).lastPathComponent
+        }
+
+        var culprit: String {
+            return "\(fileName):\(line) \(function)"
+        }
+
+        var stackTrace: [String: [[String: AnyObject]]] {
+            let frame: [String: AnyObject] = ["filename" : fileName, "function" : function, "lineno" : line]
+            return ["frames": [frame]]
+        }
+    }
+
+}
+
+extension Event {
+    func mergeSourceLocation(loc: SentryClient.SourceLocation) {
+        culprit = loc.culprit
+        stackTrace = loc.stackTrace
+    }
+}


### PR DESCRIPTION
This PR introduces a method to capture NSErrors. It's a WIP and I'd appreciate any feedback. It also doesn't include any tests yet.

### Message content

`raven-swift` and `raven-objc` have similar methods. This implementation, unlike theirs, does not send the errors description as message, as I find that to have bad readability and it may exceed the limit of 1000 characters for the message.

Instead, it sends messages similar to this:

    NSURLErrorDomain.-1004 in SomeFile.swift:99 someFunc(_:params:)

I'd like to send a more readable error name, but the only thing available at runtime is `localizedDescription`, which can be in any number of languages.

A possibility to do this would be to ship a dictionary that maps error domains and codes to their respective names, but generating such a dictionary automatically is not trivial and maintaining it manually seems unfeasible (there are at least 57 error domains in the iOS 9.3 SDK).

### userInfo

In addition, the `userInfo` dictionary is cleaned to be convertible to JSON and sent in `extra["user_info"]`.

I'm not a fan of how I implemented this and I'd love suggestions on how it could be done better. I've tried to integrate this into the `EventSerializable` protocol, but couldn't make it work due to the infamous `Protocol 'EventSerializable' can only be used as a generic constraint because it has Self or associated type requirements. `.

### Source location

I added `#file`, `#line` and `#function` parameters to the capture function. We might want to extend this to other functions and also send a single-frame stacktrace (this is what the other frameworks do), as the culprit doesn't seem to be displayed anywhere.

I have also not yet tested how (if at all) this is usable from Objective-C.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-swift/12)
<!-- Reviewable:end -->
