### PR TITLE
Refactor Project, Add Tests, Namespacing!

### DIFF
--- a/Examples/ObjCExample/ObjCExample/Base.lproj/LaunchScreen.storyboard
+++ b/Examples/ObjCExample/ObjCExample/Base.lproj/LaunchScreen.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -15,7 +16,6 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                 </viewController>

--- a/Examples/ObjCExample/ObjCExample/Base.lproj/Main.storyboard
+++ b/Examples/ObjCExample/ObjCExample/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="uNn-uZ-Zo5">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="uNn-uZ-Zo5">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -56,13 +56,22 @@
                                     <action selector="onClickComplexMessage:" destination="uNn-uZ-Zo5" eventType="touchUpInside" id="ItT-JL-aOI"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WET-pM-IcV">
+                                <rect key="frame" x="138" y="389" width="325" height="30"/>
+                                <state key="normal" title="Click this to send up an error with breadcrumbs"/>
+                                <connections>
+                                    <action selector="onClickError:" destination="uNn-uZ-Zo5" eventType="touchUpInside" id="lGl-nA-HuV"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="okv-gm-5iD" firstAttribute="centerX" secondItem="sWD-sN-dgF" secondAttribute="centerX" id="8Ez-TC-828"/>
                             <constraint firstItem="2Kc-YH-aAO" firstAttribute="top" secondItem="Rqv-XL-5gj" secondAttribute="bottom" constant="44" id="Fkr-hc-bzI"/>
                             <constraint firstItem="okv-gm-5iD" firstAttribute="top" secondItem="2Kc-YH-aAO" secondAttribute="bottom" constant="8" id="IZP-k2-uAw"/>
+                            <constraint firstItem="WET-pM-IcV" firstAttribute="top" secondItem="okv-gm-5iD" secondAttribute="bottom" constant="8" id="Ni4-Kk-Uar"/>
                             <constraint firstItem="Rqv-XL-5gj" firstAttribute="top" secondItem="St0-fT-fTG" secondAttribute="bottom" constant="144" id="dLa-b1-rc6"/>
+                            <constraint firstItem="WET-pM-IcV" firstAttribute="centerX" secondItem="sWD-sN-dgF" secondAttribute="centerX" id="mNd-Uq-BR7"/>
                             <constraint firstItem="Rqv-XL-5gj" firstAttribute="centerX" secondItem="sWD-sN-dgF" secondAttribute="centerX" id="wOH-Tn-4cn"/>
                             <constraint firstItem="2Kc-YH-aAO" firstAttribute="centerX" secondItem="sWD-sN-dgF" secondAttribute="centerX" id="wov-7K-c8Q"/>
                         </constraints>

--- a/Examples/ObjCExample/ObjCExample/ViewController.m
+++ b/Examples/ObjCExample/ObjCExample/ViewController.m
@@ -46,8 +46,14 @@
 									@"some_things": @[@"green", @"red"],
 									@"foobar": @{@"foo": @"bar"}
 									};
+    
+    // Step 5: Add breadcrumbs to help you debug errors
+    Breadcrumb *bcStart = [[Breadcrumb alloc] initWithCategory:@"test" timestamp:[NSDate new] message:nil type:nil level:SentrySeverityDebug data:@{@"navigation": @"app start"}];
+    Breadcrumb *bcMain = [[Breadcrumb alloc] initWithCategory:@"test" timestamp:[NSDate new] message:nil type:nil level:SentrySeverityDebug data:@{@"navigation": @"main screen"}];
+    [[SentryClient shared].breadcrumbs add:bcStart];
+    [[SentryClient shared].breadcrumbs add:bcMain];
 	
-	// Step 5: Don't make your app perfect so that you can get a crash ;)
+	// Step 6: Don't make your app perfect so that you can get a crash ;)
 	// See the really bad "onClickBreak" function on how to do that
 }
 
@@ -77,6 +83,27 @@
 	
 	[[SentryClient shared] captureEvent:event];
 }
+
+- (IBAction)onClickError:(id)sender {
+    NSError *error = [[NSError alloc] initWithDomain:@"test.domain" code:-1 userInfo:nil];
+    
+    Event *event = [[Event alloc] init:error.domain
+                             timestamp:[NSDate date]
+                                 level:SentrySeverityError
+                                logger:nil
+                               culprit:nil
+                            serverName:nil
+                               release:nil
+                                  tags:nil
+                               modules:nil
+                                 extra:nil
+                           fingerprint:nil
+                                  user:nil
+                      appleCrashReport:nil];
+    
+    [[SentryClient shared] captureEvent:event];
+}
+
 
 
 @end

--- a/Examples/ObjCExample/Podfile.lock
+++ b/Examples/ObjCExample/Podfile.lock
@@ -62,7 +62,7 @@ PODS:
     - KSCrash/Reporting/Tools
   - KSCrash/Reporting/Tools (1.5.7):
     - KSCrash/Recording
-  - SentrySwift (0.2.0):
+  - SentrySwift (0.2.1):
     - KSCrash (~> 1.5)
 
 DEPENDENCIES:
@@ -74,6 +74,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   KSCrash: cb2c92ee0c414db17d60a676a60fe36e3cdc6e5b
-  SentrySwift: e6de91598b999bd2af60f7cf8c44bd4c91a8739b
+  SentrySwift: a2432c5a06e7ac8ff2974b201255d751afb7264f
 
 COCOAPODS: 0.39.0

--- a/Examples/SwiftExample/Podfile.lock
+++ b/Examples/SwiftExample/Podfile.lock
@@ -62,7 +62,7 @@ PODS:
     - KSCrash/Reporting/Tools
   - KSCrash/Reporting/Tools (1.5.7):
     - KSCrash/Recording
-  - SentrySwift (0.2.0):
+  - SentrySwift (0.2.1):
     - KSCrash (~> 1.5)
 
 DEPENDENCIES:
@@ -74,6 +74,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   KSCrash: cb2c92ee0c414db17d60a676a60fe36e3cdc6e5b
-  SentrySwift: e6de91598b999bd2af60f7cf8c44bd4c91a8739b
+  SentrySwift: a2432c5a06e7ac8ff2974b201255d751afb7264f
 
 COCOAPODS: 0.39.0

--- a/Examples/SwiftTVOSExample/Podfile.lock
+++ b/Examples/SwiftTVOSExample/Podfile.lock
@@ -1,47 +1,47 @@
 PODS:
-  - KSCrash (1.5.5):
-    - KSCrash/Installations (= 1.5.5)
-  - KSCrash/Installations (1.5.5):
+  - KSCrash (1.5.7):
+    - KSCrash/Installations (= 1.5.7)
+  - KSCrash/Installations (1.5.7):
     - KSCrash/Recording
     - KSCrash/Reporting
-  - KSCrash/no-arc (1.5.5)
-  - KSCrash/Recording (1.5.5):
+  - KSCrash/no-arc (1.5.7)
+  - KSCrash/Recording (1.5.7):
     - KSCrash/no-arc
-  - KSCrash/Reporting (1.5.5):
+  - KSCrash/Reporting (1.5.7):
     - KSCrash/Recording
-    - KSCrash/Reporting/Filters (= 1.5.5)
-    - KSCrash/Reporting/MessageUI (= 1.5.5)
-    - KSCrash/Reporting/Sinks (= 1.5.5)
-    - KSCrash/Reporting/Tools (= 1.5.5)
-  - KSCrash/Reporting/Filters (1.5.5):
+    - KSCrash/Reporting/Filters (= 1.5.7)
+    - KSCrash/Reporting/MessageUI (= 1.5.7)
+    - KSCrash/Reporting/Sinks (= 1.5.7)
+    - KSCrash/Reporting/Tools (= 1.5.7)
+  - KSCrash/Reporting/Filters (1.5.7):
     - KSCrash/Recording
-    - KSCrash/Reporting/Filters/Alert (= 1.5.5)
-    - KSCrash/Reporting/Filters/AppleFmt (= 1.5.5)
-    - KSCrash/Reporting/Filters/Base (= 1.5.5)
-    - KSCrash/Reporting/Filters/Basic (= 1.5.5)
-    - KSCrash/Reporting/Filters/GZip (= 1.5.5)
-    - KSCrash/Reporting/Filters/JSON (= 1.5.5)
-    - KSCrash/Reporting/Filters/Sets (= 1.5.5)
-    - KSCrash/Reporting/Filters/Stringify (= 1.5.5)
-    - KSCrash/Reporting/Filters/Tools (= 1.5.5)
-  - KSCrash/Reporting/Filters/Alert (1.5.5):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/AppleFmt (1.5.5):
+    - KSCrash/Reporting/Filters/Alert (= 1.5.7)
+    - KSCrash/Reporting/Filters/AppleFmt (= 1.5.7)
+    - KSCrash/Reporting/Filters/Base (= 1.5.7)
+    - KSCrash/Reporting/Filters/Basic (= 1.5.7)
+    - KSCrash/Reporting/Filters/GZip (= 1.5.7)
+    - KSCrash/Reporting/Filters/JSON (= 1.5.7)
+    - KSCrash/Reporting/Filters/Sets (= 1.5.7)
+    - KSCrash/Reporting/Filters/Stringify (= 1.5.7)
+    - KSCrash/Reporting/Filters/Tools (= 1.5.7)
+  - KSCrash/Reporting/Filters/Alert (1.5.7):
     - KSCrash/Recording
     - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/Base (1.5.5):
-    - KSCrash/Recording
-  - KSCrash/Reporting/Filters/Basic (1.5.5):
+  - KSCrash/Reporting/Filters/AppleFmt (1.5.7):
     - KSCrash/Recording
     - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/GZip (1.5.5):
+  - KSCrash/Reporting/Filters/Base (1.5.7):
+    - KSCrash/Recording
+  - KSCrash/Reporting/Filters/Basic (1.5.7):
     - KSCrash/Recording
     - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/JSON (1.5.5):
+  - KSCrash/Reporting/Filters/GZip (1.5.7):
     - KSCrash/Recording
     - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/Sets (1.5.5):
+  - KSCrash/Reporting/Filters/JSON (1.5.7):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/Sets (1.5.7):
     - KSCrash/Recording
     - KSCrash/Reporting/Filters/AppleFmt
     - KSCrash/Reporting/Filters/Base
@@ -49,20 +49,20 @@ PODS:
     - KSCrash/Reporting/Filters/GZip
     - KSCrash/Reporting/Filters/JSON
     - KSCrash/Reporting/Filters/Stringify
-  - KSCrash/Reporting/Filters/Stringify (1.5.5):
+  - KSCrash/Reporting/Filters/Stringify (1.5.7):
     - KSCrash/Recording
     - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/Tools (1.5.5):
+  - KSCrash/Reporting/Filters/Tools (1.5.7):
     - KSCrash/Recording
-  - KSCrash/Reporting/MessageUI (1.5.5):
+  - KSCrash/Reporting/MessageUI (1.5.7):
     - KSCrash/Recording
-  - KSCrash/Reporting/Sinks (1.5.5):
+  - KSCrash/Reporting/Sinks (1.5.7):
     - KSCrash/Recording
     - KSCrash/Reporting/Filters
     - KSCrash/Reporting/Tools
-  - KSCrash/Reporting/Tools (1.5.5):
+  - KSCrash/Reporting/Tools (1.5.7):
     - KSCrash/Recording
-  - SentrySwift (0.1.1):
+  - SentrySwift (0.2.1):
     - KSCrash (~> 1.5)
 
 DEPENDENCIES:
@@ -73,9 +73,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  KSCrash: 10d24687c924420cdfd92b4c48b3703c5d333452
-  SentrySwift: 260d20a7b81f70c915f591edf3a68619c33187aa
+  KSCrash: cb2c92ee0c414db17d60a676a60fe36e3cdc6e5b
+  SentrySwift: a2432c5a06e7ac8ff2974b201255d751afb7264f
 
-PODFILE CHECKSUM: c2c46ed548b6de63b5eb1ab2f9925ced0eddf587
-
-COCOAPODS: 1.0.0
+COCOAPODS: 0.39.0

--- a/Examples/SwiftTVOSExample/SwiftTVOSExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftTVOSExample/SwiftTVOSExample.xcodeproj/project.pbxproj
@@ -1,362 +1,707 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		03C715401CE4E1E90080AE60 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C7153F1CE4E1E90080AE60 /* AppDelegate.swift */; };
-		03C715421CE4E1E90080AE60 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C715411CE4E1E90080AE60 /* ViewController.swift */; };
-		03C715451CE4E1E90080AE60 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03C715431CE4E1E90080AE60 /* Main.storyboard */; };
-		03C715471CE4E1E90080AE60 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03C715461CE4E1E90080AE60 /* Assets.xcassets */; };
-		B88FC4A5A329F7FADEA48815 /* Pods_SwiftTVOSExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9DC6DA663897FBF385BD56A /* Pods_SwiftTVOSExample.framework */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXFileReference section */
-		03C7153C1CE4E1E90080AE60 /* SwiftTVOSExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftTVOSExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		03C7153F1CE4E1E90080AE60 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		03C715411CE4E1E90080AE60 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		03C715441CE4E1E90080AE60 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		03C715461CE4E1E90080AE60 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		03C715481CE4E1E90080AE60 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6431B937E8619003EBE93F0D /* Pods-SwiftTVOSExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftTVOSExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftTVOSExample/Pods-SwiftTVOSExample.debug.xcconfig"; sourceTree = "<group>"; };
-		792767155FE9883FF2204F59 /* Pods-SwiftTVOSExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftTVOSExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftTVOSExample/Pods-SwiftTVOSExample.release.xcconfig"; sourceTree = "<group>"; };
-		D9DC6DA663897FBF385BD56A /* Pods_SwiftTVOSExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftTVOSExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		03C715391CE4E1E90080AE60 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B88FC4A5A329F7FADEA48815 /* Pods_SwiftTVOSExample.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		03C715331CE4E1E90080AE60 = {
-			isa = PBXGroup;
-			children = (
-				03C7153E1CE4E1E90080AE60 /* SwiftTVOSExample */,
-				03C7153D1CE4E1E90080AE60 /* Products */,
-				3B6E6B1E0E21D9D7163AD5BA /* Pods */,
-				B86A963FEAB848A70A2A4710 /* Frameworks */,
-			);
-			sourceTree = "<group>";
-		};
-		03C7153D1CE4E1E90080AE60 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				03C7153C1CE4E1E90080AE60 /* SwiftTVOSExample.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		03C7153E1CE4E1E90080AE60 /* SwiftTVOSExample */ = {
-			isa = PBXGroup;
-			children = (
-				03C7153F1CE4E1E90080AE60 /* AppDelegate.swift */,
-				03C715411CE4E1E90080AE60 /* ViewController.swift */,
-				03C715431CE4E1E90080AE60 /* Main.storyboard */,
-				03C715461CE4E1E90080AE60 /* Assets.xcassets */,
-				03C715481CE4E1E90080AE60 /* Info.plist */,
-			);
-			path = SwiftTVOSExample;
-			sourceTree = "<group>";
-		};
-		3B6E6B1E0E21D9D7163AD5BA /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				6431B937E8619003EBE93F0D /* Pods-SwiftTVOSExample.debug.xcconfig */,
-				792767155FE9883FF2204F59 /* Pods-SwiftTVOSExample.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		B86A963FEAB848A70A2A4710 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				D9DC6DA663897FBF385BD56A /* Pods_SwiftTVOSExample.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXNativeTarget section */
-		03C7153B1CE4E1E90080AE60 /* SwiftTVOSExample */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 03C7154B1CE4E1E90080AE60 /* Build configuration list for PBXNativeTarget "SwiftTVOSExample" */;
-			buildPhases = (
-				8556D6D4295671E5FC945345 /* 📦 Check Pods Manifest.lock */,
-				03C715381CE4E1E90080AE60 /* Sources */,
-				03C715391CE4E1E90080AE60 /* Frameworks */,
-				03C7153A1CE4E1E90080AE60 /* Resources */,
-				5FE19D848E2834BB6E69B35F /* 📦 Embed Pods Frameworks */,
-				3C8831DBE5820C85CDCAEDAB /* 📦 Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SwiftTVOSExample;
-			productName = SwiftTVOSExample;
-			productReference = 03C7153C1CE4E1E90080AE60 /* SwiftTVOSExample.app */;
-			productType = "com.apple.product-type.application";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		03C715341CE4E1E90080AE60 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
-				ORGANIZATIONNAME = RokkinCat;
-				TargetAttributes = {
-					03C7153B1CE4E1E90080AE60 = {
-						CreatedOnToolsVersion = 7.3.1;
-					};
-				};
-			};
-			buildConfigurationList = 03C715371CE4E1E90080AE60 /* Build configuration list for PBXProject "SwiftTVOSExample" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
-			mainGroup = 03C715331CE4E1E90080AE60;
-			productRefGroup = 03C7153D1CE4E1E90080AE60 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				03C7153B1CE4E1E90080AE60 /* SwiftTVOSExample */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXResourcesBuildPhase section */
-		03C7153A1CE4E1E90080AE60 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				03C715471CE4E1E90080AE60 /* Assets.xcassets in Resources */,
-				03C715451CE4E1E90080AE60 /* Main.storyboard in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		3C8831DBE5820C85CDCAEDAB /* 📦 Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "📦 Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftTVOSExample/Pods-SwiftTVOSExample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5FE19D848E2834BB6E69B35F /* 📦 Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "📦 Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftTVOSExample/Pods-SwiftTVOSExample-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8556D6D4295671E5FC945345 /* 📦 Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "📦 Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		03C715381CE4E1E90080AE60 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				03C715421CE4E1E90080AE60 /* ViewController.swift in Sources */,
-				03C715401CE4E1E90080AE60 /* AppDelegate.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXVariantGroup section */
-		03C715431CE4E1E90080AE60 /* Main.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				03C715441CE4E1E90080AE60 /* Base */,
-			);
-			name = Main.storyboard;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
-/* Begin XCBuildConfiguration section */
-		03C715491CE4E1E90080AE60 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = appletvos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.2;
-			};
-			name = Debug;
-		};
-		03C7154A1CE4E1E90080AE60 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = appletvos;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.2;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		03C7154C1CE4E1E90080AE60 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6431B937E8619003EBE93F0D /* Pods-SwiftTVOSExample.debug.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				INFOPLIST_FILE = SwiftTVOSExample/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.rokkincat.SwiftTVOSExample;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Debug;
-		};
-		03C7154D1CE4E1E90080AE60 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 792767155FE9883FF2204F59 /* Pods-SwiftTVOSExample.release.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				INFOPLIST_FILE = SwiftTVOSExample/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.rokkincat.SwiftTVOSExample;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		03C715371CE4E1E90080AE60 /* Build configuration list for PBXProject "SwiftTVOSExample" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				03C715491CE4E1E90080AE60 /* Debug */,
-				03C7154A1CE4E1E90080AE60 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		03C7154B1CE4E1E90080AE60 /* Build configuration list for PBXNativeTarget "SwiftTVOSExample" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				03C7154C1CE4E1E90080AE60 /* Debug */,
-				03C7154D1CE4E1E90080AE60 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = 03C715341CE4E1E90080AE60 /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>03C715331CE4E1E90080AE60</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>03C7153E1CE4E1E90080AE60</string>
+				<string>03C7153D1CE4E1E90080AE60</string>
+				<string>3B6E6B1E0E21D9D7163AD5BA</string>
+				<string>B86A963FEAB848A70A2A4710</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03C715341CE4E1E90080AE60</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastSwiftUpdateCheck</key>
+				<string>0730</string>
+				<key>LastUpgradeCheck</key>
+				<string>0730</string>
+				<key>ORGANIZATIONNAME</key>
+				<string>RokkinCat</string>
+				<key>TargetAttributes</key>
+				<dict>
+					<key>03C7153B1CE4E1E90080AE60</key>
+					<dict>
+						<key>CreatedOnToolsVersion</key>
+						<string>7.3.1</string>
+					</dict>
+				</dict>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>03C715371CE4E1E90080AE60</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+				<string>Base</string>
+			</array>
+			<key>mainGroup</key>
+			<string>03C715331CE4E1E90080AE60</string>
+			<key>productRefGroup</key>
+			<string>03C7153D1CE4E1E90080AE60</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>03C7153B1CE4E1E90080AE60</string>
+			</array>
+		</dict>
+		<key>03C715371CE4E1E90080AE60</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>03C715491CE4E1E90080AE60</string>
+				<string>03C7154A1CE4E1E90080AE60</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>03C715381CE4E1E90080AE60</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>03C715421CE4E1E90080AE60</string>
+				<string>03C715401CE4E1E90080AE60</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>03C715391CE4E1E90080AE60</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>B88FC4A5A329F7FADEA48815</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>03C7153A1CE4E1E90080AE60</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>03C715471CE4E1E90080AE60</string>
+				<string>03C715451CE4E1E90080AE60</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>03C7153B1CE4E1E90080AE60</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>03C7154B1CE4E1E90080AE60</string>
+			<key>buildPhases</key>
+			<array>
+				<string>8556D6D4295671E5FC945345</string>
+				<string>03C715381CE4E1E90080AE60</string>
+				<string>03C715391CE4E1E90080AE60</string>
+				<string>03C7153A1CE4E1E90080AE60</string>
+				<string>5FE19D848E2834BB6E69B35F</string>
+				<string>3C8831DBE5820C85CDCAEDAB</string>
+				<string>17708BAA26333D3EC6C3A879</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>SwiftTVOSExample</string>
+			<key>productName</key>
+			<string>SwiftTVOSExample</string>
+			<key>productReference</key>
+			<string>03C7153C1CE4E1E90080AE60</string>
+			<key>productType</key>
+			<string>com.apple.product-type.application</string>
+		</dict>
+		<key>03C7153C1CE4E1E90080AE60</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.application</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>SwiftTVOSExample.app</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>03C7153D1CE4E1E90080AE60</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>03C7153C1CE4E1E90080AE60</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03C7153E1CE4E1E90080AE60</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>03C7153F1CE4E1E90080AE60</string>
+				<string>03C715411CE4E1E90080AE60</string>
+				<string>03C715431CE4E1E90080AE60</string>
+				<string>03C715461CE4E1E90080AE60</string>
+				<string>03C715481CE4E1E90080AE60</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>SwiftTVOSExample</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03C7153F1CE4E1E90080AE60</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>AppDelegate.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03C715401CE4E1E90080AE60</key>
+		<dict>
+			<key>fileRef</key>
+			<string>03C7153F1CE4E1E90080AE60</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>03C715411CE4E1E90080AE60</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>ViewController.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03C715421CE4E1E90080AE60</key>
+		<dict>
+			<key>fileRef</key>
+			<string>03C715411CE4E1E90080AE60</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>03C715431CE4E1E90080AE60</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>03C715441CE4E1E90080AE60</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>Main.storyboard</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03C715441CE4E1E90080AE60</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>file.storyboard</string>
+			<key>name</key>
+			<string>Base</string>
+			<key>path</key>
+			<string>Base.lproj/Main.storyboard</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03C715451CE4E1E90080AE60</key>
+		<dict>
+			<key>fileRef</key>
+			<string>03C715431CE4E1E90080AE60</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>03C715461CE4E1E90080AE60</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>folder.assetcatalog</string>
+			<key>path</key>
+			<string>Assets.xcassets</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03C715471CE4E1E90080AE60</key>
+		<dict>
+			<key>fileRef</key>
+			<string>03C715461CE4E1E90080AE60</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>03C715481CE4E1E90080AE60</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03C715491CE4E1E90080AE60</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_ANALYZER_NONNULL</key>
+				<string>YES</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>ENABLE_TESTABILITY</key>
+				<string>YES</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_NO_COMMON_BLOCKS</key>
+				<string>YES</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>SDKROOT</key>
+				<string>appletvos</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>3</string>
+				<key>TVOS_DEPLOYMENT_TARGET</key>
+				<string>9.2</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>03C7154A1CE4E1E90080AE60</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_ANALYZER_NONNULL</key>
+				<string>YES</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_NO_COMMON_BLOCKS</key>
+				<string>YES</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>SDKROOT</key>
+				<string>appletvos</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>3</string>
+				<key>TVOS_DEPLOYMENT_TARGET</key>
+				<string>9.2</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>03C7154B1CE4E1E90080AE60</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>03C7154C1CE4E1E90080AE60</string>
+				<string>03C7154D1CE4E1E90080AE60</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>03C7154C1CE4E1E90080AE60</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>6431B937E8619003EBE93F0D</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
+				<string>App Icon &amp; Top Shelf Image</string>
+				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
+				<string>LaunchImage</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>INFOPLIST_FILE</key>
+				<string>SwiftTVOSExample/Info.plist</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.rokkincat.SwiftTVOSExample</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>03C7154D1CE4E1E90080AE60</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>792767155FE9883FF2204F59</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
+				<string>App Icon &amp; Top Shelf Image</string>
+				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
+				<string>LaunchImage</string>
+				<key>INFOPLIST_FILE</key>
+				<string>SwiftTVOSExample/Info.plist</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.rokkincat.SwiftTVOSExample</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>17708BAA26333D3EC6C3A879</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Embed Pods Frameworks</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-SwiftTVOSExample/Pods-SwiftTVOSExample-frameworks.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>3B6E6B1E0E21D9D7163AD5BA</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>6431B937E8619003EBE93F0D</string>
+				<string>792767155FE9883FF2204F59</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3C8831DBE5820C85CDCAEDAB</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>&#128230; Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-SwiftTVOSExample/Pods-SwiftTVOSExample-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>5FE19D848E2834BB6E69B35F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>&#128230; Embed Pods Frameworks</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-SwiftTVOSExample/Pods-SwiftTVOSExample-frameworks.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>6431B937E8619003EBE93F0D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-SwiftTVOSExample.debug.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-SwiftTVOSExample/Pods-SwiftTVOSExample.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>792767155FE9883FF2204F59</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-SwiftTVOSExample.release.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-SwiftTVOSExample/Pods-SwiftTVOSExample.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8556D6D4295671E5FC945345</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>&#128230; Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>B86A963FEAB848A70A2A4710</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>D9DC6DA663897FBF385BD56A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B88FC4A5A329F7FADEA48815</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D9DC6DA663897FBF385BD56A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>D9DC6DA663897FBF385BD56A</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods_SwiftTVOSExample.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>03C715341CE4E1E90080AE60</string>
+</dict>
+</plist>

--- a/SentrySwift.xcodeproj/project.pbxproj
+++ b/SentrySwift.xcodeproj/project.pbxproj
@@ -65,6 +65,12 @@
 		03FF07C61CE545D300BA980E /* SentrySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035242971C988D2F00A65D6D /* SentrySwiftTests.swift */; };
 		03FF07C71CE545D300BA980E /* SentrySwiftBreadcrumbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D4D9FF1CA586EF00799CC9 /* SentrySwiftBreadcrumbTests.swift */; };
 		03FF07C81CE546B500BA980E /* Abort.json in Resources */ = {isa = PBXBuildFile; fileRef = 035242941C988D2F00A65D6D /* Abort.json */; };
+		9B02CAB71CF5C20F004F614C /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */; };
+		9B02CAB81CF5C20F004F614C /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */; };
+		9B02CAB91CF5C20F004F614C /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */; };
+		9B02CABC1CF5C270004F614C /* NSDate+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */; };
+		9B02CABD1CF5C270004F614C /* NSDate+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */; };
+		9B02CABE1CF5C270004F614C /* NSDate+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -172,6 +178,8 @@
 		03E94AF61C22595C009F8F29 /* SentrySwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SentrySwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03E94B0B1C22596A009F8F29 /* SentrySwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SentrySwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		03E94B141C22596A009F8F29 /* SentrySwift-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SentrySwift-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
+		9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Extras.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -259,6 +267,7 @@
 		036378271C225D5200644C01 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				9B02CAB11CF5C1E8004F614C /* Extensions */,
 				036378281C225D5200644C01 /* SentrySwift.h */,
 				0363782B1C225D8300644C01 /* Sentry.swift */,
 				03E3D1F71C3E1A2800F00547 /* DSN.swift */,
@@ -348,6 +357,31 @@
 				03C714E01CE4D2090080AE60 /* KSCrash-TVOS.xcodeproj */,
 			);
 			name = KSCrash;
+			sourceTree = "<group>";
+		};
+		9B02CAB11CF5C1E8004F614C /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				9B02CABA1CF5C25D004F614C /* Foundation */,
+				9B02CAB51CF5C1F9004F614C /* Swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
+		9B02CAB51CF5C1F9004F614C /* Swift */ = {
+			isa = PBXGroup;
+			children = (
+				9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */,
+			);
+			name = Swift;
+			sourceTree = "<group>";
+		};
+		9B02CABA1CF5C25D004F614C /* Foundation */ = {
+			isa = PBXGroup;
+			children = (
+				9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */,
+			);
+			name = Foundation;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -646,10 +680,12 @@
 			files = (
 				03C7152B1CE4DB940080AE60 /* AppleCrashReport.swift in Sources */,
 				03C7152C1CE4DB940080AE60 /* Breadcrumb.swift in Sources */,
+				9B02CAB91CF5C20F004F614C /* Dictionary+Extras.swift in Sources */,
 				03C715271CE4DB910080AE60 /* Event.swift in Sources */,
 				03C715241CE4DB8D0080AE60 /* Sentry.swift in Sources */,
 				03C7152A1CE4DB910080AE60 /* EventSerializable.swift in Sources */,
 				03C7152E1CE4DB940080AE60 /* BreadcrumbStore.swift in Sources */,
+				9B02CABE1CF5C270004F614C /* NSDate+Extras.swift in Sources */,
 				03C715281CE4DB910080AE60 /* EventOffline.swift in Sources */,
 				03C715261CE4DB8D0080AE60 /* Request.swift in Sources */,
 				03C7152F1CE4DB980080AE60 /* CrashHandler.swift in Sources */,
@@ -679,9 +715,11 @@
 				03E3D21F1C3EB20F00F00547 /* Request.swift in Sources */,
 				0363782C1C225D8300644C01 /* Sentry.swift in Sources */,
 				03D4D9F91CA48FA800799CC9 /* Breadcrumb.swift in Sources */,
+				9B02CAB71CF5C20F004F614C /* Dictionary+Extras.swift in Sources */,
 				03C1E5A71C57192A004D68D8 /* EventOffline.swift in Sources */,
 				03E3D1F81C3E1A2800F00547 /* DSN.swift in Sources */,
 				033A342C1C60693400BED5AE /* User.swift in Sources */,
+				9B02CABC1CF5C270004F614C /* NSDate+Extras.swift in Sources */,
 				036378321C227C7900644C01 /* Event.swift in Sources */,
 				0303BC3F1C29FC3F003E7B16 /* EventSerializable.swift in Sources */,
 				0370617F1C75446B0082CCCE /* AppleCrashReport.swift in Sources */,
@@ -705,10 +743,12 @@
 			files = (
 				03C736E21C474715004428DF /* CrashHandler.swift in Sources */,
 				037061801C75446B0082CCCE /* AppleCrashReport.swift in Sources */,
+				9B02CAB81CF5C20F004F614C /* Dictionary+Extras.swift in Sources */,
 				033A342A1C605B7E00BED5AE /* EventProperties.swift in Sources */,
 				03E3D2201C3EB20F00F00547 /* Request.swift in Sources */,
 				0363782D1C225D8300644C01 /* Sentry.swift in Sources */,
 				03CFCEC21C612F3E00999EB7 /* KSCrashHandler.swift in Sources */,
+				9B02CABD1CF5C270004F614C /* NSDate+Extras.swift in Sources */,
 				03C1E5A81C57192A004D68D8 /* EventOffline.swift in Sources */,
 				033A342D1C60693400BED5AE /* User.swift in Sources */,
 				03E3D1F91C3E1A2800F00547 /* DSN.swift in Sources */,

--- a/SentrySwiftTests/SentrySwiftBreadcrumbTests.swift
+++ b/SentrySwiftTests/SentrySwiftBreadcrumbTests.swift
@@ -5,8 +5,10 @@
 //  Created by Josh Holtz on 3/25/16.
 //
 //
+
 import XCTest
 import SentrySwift
+@testable import SentrySwift
 
 class SentrySwiftBreadcrumbTests: XCTestCase {
 	
@@ -43,20 +45,20 @@ class SentrySwiftBreadcrumbTests: XCTestCase {
 		let test4 = Breadcrumb(category: "test", message: "Test 4")
 		
 		store.add(test1)
-		XCTAssertEqual(store.get()?.count, 1)
-		XCTAssertEqual(store.get()!, [test1])
+		XCTAssertEqual(store.crumbs.count, 1)
+		XCTAssertEqual(store.crumbs, [test1])
 		
 		store.add(test2)
-		XCTAssertEqual(store.get()?.count, 2)
-		XCTAssertEqual(store.get()!, [test1, test2])
+		XCTAssertEqual(store.crumbs.count, 2)
+		XCTAssertEqual(store.crumbs, [test1, test2])
 		
 		store.add(test3)
-		XCTAssertEqual(store.get()?.count, 3)
-		XCTAssertEqual(store.get()!, [test1, test2, test3])
+		XCTAssertEqual(store.crumbs.count, 3)
+		XCTAssertEqual(store.crumbs, [test1, test2, test3])
 		
 		store.add(test4)
-		XCTAssertEqual(store.get()?.count, 3)
-		XCTAssertEqual(store.get()!, [test2, test3, test4])
+		XCTAssertEqual(store.crumbs.count, 3)
+		XCTAssertEqual(store.crumbs, [test2, test3, test4])
 	}
 
 }

--- a/SentrySwiftTests/SentrySwiftObjCTests.m
+++ b/SentrySwiftTests/SentrySwiftObjCTests.m
@@ -34,7 +34,7 @@
 - (void)testThatThingsCompileBecauseSwiftToOjbCBridge {
 	[SentryClient setLogLevel:SentryLogDebug];
 	
-	[[SentryClient shared] setCrashHandler:[[SentryKSCrashHandler alloc] init]];
+	[[SentryClient shared] startCrashHandler];
 	[SentryClient shared].user = [[User alloc] initWithId:@"3" email:@"example@example.com" username:@"Example" extra:@{@"is_admin": @NO}];
 	[SentryClient shared].tags = @{@"environment": @"production"};
 	[SentryClient shared].extra = @{
@@ -45,6 +45,9 @@
 
 	SentryClient *nilClient = nil;
 	[nilClient captureMessage:@"Some plain message from ObjC" level:SentrySeverityInfo];
+    
+    Breadcrumb *bc = [[Breadcrumb alloc] initWithCategory:@"test" timestamp:[NSDate new] message:@"test message" type:@"test" level:SentrySeverityDebug data:nil];
+    [[SentryClient shared].breadcrumbs add:bc];
 }
 
 - (void)testEvent {
@@ -77,7 +80,7 @@
 	XCTAssertEqual(event.eventID.length, 32);
 	XCTAssertEqualObjects(event.message, message);
 	XCTAssertEqual(event.level, SentrySeverityError);
-	XCTAssertEqualObjects(event.platform, [Event platform]);
+	XCTAssertEqualObjects(event.platform, @"cocoa");
 	XCTAssertEqualObjects(event.logger, logger);
 	XCTAssertEqualObjects(event.culprit, culprit);
 	XCTAssertEqualObjects(event.serverName, serverName);

--- a/SentrySwiftTests/SentrySwiftTests.swift
+++ b/SentrySwiftTests/SentrySwiftTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import SentrySwift
+@testable import SentrySwift
 
 class SentrySwiftTests: XCTestCase {
 	
@@ -27,14 +28,6 @@ class SentrySwiftTests: XCTestCase {
 	}
 	
 	// MARK: Helpers
-	
-    func testOS() {
-		#if os(iOS)
-			assert(client.os == .IOS)
-		#elseif os(OSX)
-			assert(client.os == .OSX)
-		#endif
-    }
 	
 	func testDateSerialization() {
 		let dateString = "2011-05-02T17:41:36"
@@ -105,8 +98,8 @@ class SentrySwiftTests: XCTestCase {
 		let header = dsn.xSentryAuthHeader
 		assert(header.key == "X-Sentry-Auth")
 		assert(header.value.rangeOfString("Sentry ") != nil)
-		assert(header.value.rangeOfString("sentry_version=\(SentryInfo.sentryVersion)") != nil)
-		assert(header.value.rangeOfString("sentry_client=sentry-swift/\(SentryInfo.version)") != nil)
+		assert(header.value.rangeOfString("sentry_version=\(SentryClient.Info.sentryVersion)") != nil)
+		assert(header.value.rangeOfString("sentry_client=sentry-swift/\(SentryClient.Info.version)") != nil)
 		assert(header.value.rangeOfString("sentry_timestamp=") != nil)
 		
 		if let key = dsn.publicKey {
@@ -132,7 +125,7 @@ class SentrySwiftTests: XCTestCase {
 		assert(event.eventID.characters.count == 32)
 		assert(event.message == message)
 		assert(event.level == .Error)
-		assert(event.platform == Event.platform)
+		assert(event.platform == "cocoa")
 	}
 
 	func testEventWithOptionals() {
@@ -235,7 +228,7 @@ class SentrySwiftTests: XCTestCase {
 		assert((serialized["event_id"] as! String).characters.count == 32)
 		assert(serialized["message"] as! String == message)
 		assert(serialized["timestamp"] as! String == dateString)
-		assert(serialized["level"] as! String == level.name)
+		assert(serialized["level"] as! String == level.description)
 		assert(serialized["platform"] as! String == platform)
 		
 		// Optional
@@ -264,7 +257,7 @@ class SentrySwiftTests: XCTestCase {
 		client.user = User(id: "3", email: "things@example.com", username: "things")
 		
 		// Create event
-		let event = Event("Lalalala")
+		var event = Event("Lalalala")
 		event.tags = [
 			"tag_event": "value_event",
 			"tag_client_event": "event_wins"
@@ -289,7 +282,7 @@ class SentrySwiftTests: XCTestCase {
 		assert(event.user!.username! == "stuff")
 		
 		// Merge
-		event.mergeProperties(client)
+		event.mergeProperties(from: client)
 		
 		// Test after merge
 		assert(event.tags! == [

--- a/Sources/AppleCrashReport.swift
+++ b/Sources/AppleCrashReport.swift
@@ -8,26 +8,33 @@
 
 import Foundation
 
-/// A class used to represent the apple crash report attached to an event
+/// A class used to represent the Apple crash report attached to an event
 @objc public class AppleCrashReport: NSObject {
+
+	// MARK: - Attributes
+
 	public var crash: [String: AnyObject]
 	public var binaryImages: [[String: AnyObject]]
 	public var system: [String: AnyObject]
 	
-	/// Creates an apple crash report
-	/// - Parameter crash: A dictionary of crash info
-	/// - Parameter binaryImages: An array of dictionaries of binary images
-	/// - Parameter system: A dictionary of system info for the crash
+	/*
+	Creates an apple crash report
+	- Parameter crash: A dictionary of crash info
+	- Parameter binaryImages: An array of dictionaries of binary images
+	- Parameter system: A dictionary of system info for the crash
+	*/
 	public init(crash: [String: AnyObject], binaryImages: [[String: AnyObject]], system: [String: AnyObject]) {
 		self.crash = crash
 		self.binaryImages = binaryImages
 		self.system = system
+
+		super.init()
 	}
 }
 
 extension AppleCrashReport: EventSerializable {
-	public typealias SerializedType = SerializedTypeDictionary
-	public var serialized: SerializedType {
+	internal typealias SerializedType = SerializedTypeDictionary
+	internal var serialized: SerializedType {
 		return [
 			"crash": crash,
 			"binary_images": binaryImages,

--- a/Sources/Breadcrumb.swift
+++ b/Sources/Breadcrumb.swift
@@ -8,74 +8,56 @@
 
 import Foundation
 
-// Note: These Breadcrumbs are created an convenience initializers
-// due to compatibility with Objective-C. These should really be
-// enums with associative values (because much cleaner) but
-// Objective-C does not recognize them.
-
-/// A class used to represent the breadcrumbs attached to events
+/// A class used to represent the breadcrumbs leading up to an events
 @objc public class Breadcrumb: NSObject {
-	
-	public var timestamp: NSDate
+
+	// MARK: - Attributes
+
+	public let timestamp: NSDate
 	public var category: String
-	
+
 	public var type: String?
 	public var message: String?
 	public var data: [String: AnyObject]
-	public var level: SentrySeverity?
-	
-	/// Creates a user
-	public init(category: String, timestamp: NSDate = NSDate(), message: String? = nil, type: String? = nil, level: SentrySeverity? = nil, data: [String: AnyObject]? = nil) {
+	public var level: SentrySeverity // can't be optional because @objc can't handle optional enums
+
+
+	/// Creates a breadcrumb
+	@objc public init(category: String, timestamp: NSDate = NSDate(), message: String? = nil, type: String? = nil, level: SentrySeverity = .Info, data: [String: AnyObject]? = nil) {
 		self.category = category
 		self.timestamp = timestamp
 		self.message = message
 		self.type = type
 		self.data = data ?? [:]
+		self.level = level
+
+		super.init()
 	}
 
-}
+	/// Conveneince init for a "navigation" type breadcrumb
+	public convenience init(category: String, timestamp: NSDate = NSDate(), message: String? = nil, level: SentrySeverity = .Info, data: [String: AnyObject]? = nil, to: String, from: String? = nil) {
+		let navigationData: [String: AnyObject] = (data ?? [:])
+		.set("to", value: to)
+		.set("from", value: from)
 
-extension Dictionary {
-	
-	// Sets the key and value but only if value is non-nil
-	func set(key: Key, value: Value?) -> Dictionary<Key, Value> {
-		guard let value = value else { return self }
-		
-		var newDict = self
-		newDict[key] = value
-		
-		return newDict
-	}
-	
-}
-
-extension Breadcrumb {
-	
-	public convenience init(category: String, timestamp: NSDate = NSDate(), message: String? = nil, level: SentrySeverity? = nil, data: [String: AnyObject]? = nil, to: String, from: String? = nil) {
-		
-		let navigationData = (data ?? [:])
-			.set("to", value: to)
-			.set("from", value: from)
-		
 		self.init(category: category, timestamp: timestamp, message: message, type: "navigation", level: level, data: navigationData)
 	}
-	
-	public convenience init(category: String, timestamp: NSDate = NSDate(), message: String? = nil, level: SentrySeverity? = nil, data: [String: AnyObject]? = nil, url: String, method: String, statusCode: Int? = nil, reason: String? = nil) {
-		
-		let httpData = (data ?? [:])
-			.set("url", value: url)
-			.set("method", value: method)
-			.set("status_code", value: statusCode)
-			.set("reason", value: "reason")
-		
+
+	/// Conveneince init for an "http" type breadcrumb (-999 workaround because @objc can't handle optional Int)
+	public convenience init(category: String, timestamp: NSDate = NSDate(), message: String? = nil, level: SentrySeverity = .Info, data: [String: AnyObject]? = nil, url: String, method: String, statusCode: Int = -999, reason: String? = nil) {
+		let httpData: [String: AnyObject] = (data ?? [:])
+		.set("url", value: url)
+		.set("method", value: method)
+		.set("status_code", value: statusCode == -999 ? nil : statusCode)
+		.set("reason", value: "reason")
+
 		self.init(category: category, timestamp: timestamp, message: message, type: "http", level: level, data: httpData)
 	}
-	
 }
 
 extension Breadcrumb: EventSerializable {
-	public typealias SerializedType = SerializedTypeDictionary
-	public var serialized: SerializedType {
+	internal typealias SerializedType = SerializedTypeDictionary
+	internal var serialized: SerializedType {
 		return [
 			"category": category,
 			"timestamp": timestamp.iso8601,
@@ -83,6 +65,6 @@ extension Breadcrumb: EventSerializable {
 		]
 		.set("type", value: type)
 		.set("message", value: message)
-		.set("level", value: level?.name)
+		.set("level", value: level.description)
 	}
 }

--- a/Sources/BreadcrumbStore.swift
+++ b/Sources/BreadcrumbStore.swift
@@ -8,43 +8,44 @@
 
 import Foundation
 
-@objc public class BreadcrumbStore: NSObject {
-	
-	private var crumbs = [Breadcrumb]()
-	
-	private var _maxCrumbs = 20
-	public var maxCrumbs: Int {
+/// A class used to hold and store our `Breadcrumb`
+public class BreadcrumbStore: NSObject {
+
+	public typealias StoreUpdated = (BreadcrumbStore) -> ()
+
+	// MARK: - Attributes
+
+	private(set) var crumbs: [Breadcrumb] = []
+
+	private var _maxCrumbs: Int = 20
+	internal var maxCrumbs: Int {
 		get { return _maxCrumbs }
 		set { _maxCrumbs = max(0, newValue) }
 	}
-	
-	public typealias StoreUpdated = (BreadcrumbStore) -> ()
-	public var storeUpdated: StoreUpdated?
-	
+
+	internal var storeUpdated: StoreUpdated?
+
+
+	// MARK: - Public Interface
+
+	/// Adds given crumb to the client store
 	public func add(crumb: Breadcrumb) {
-		
 		if crumbs.count >= maxCrumbs {
 			crumbs.removeFirst()
 		}
+
 		crumbs.append(crumb)
-		
-		storeUpdated?(self)
 	}
-	
-	public func get() -> [Breadcrumb]? {
-		return crumbs
-	}
-	
+
+	/// Clears the store for given type or all if none specified
 	public func clear() {
 		crumbs.removeAll()
-		storeUpdated?(self)
 	}
-	
 }
 
 extension BreadcrumbStore: EventSerializable {
-	public typealias SerializedType = SerializedTypeArray
-	public var serialized: SerializedType {
+	internal typealias SerializedType = SerializedTypeArray
+	internal var serialized: SerializedType {
 		return crumbs.map{$0.serialized}.flatMap{$0}
 	}
 }

--- a/Sources/CrashHandler.swift
+++ b/Sources/CrashHandler.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@objc public protocol CrashHandler: EventProperties {
+internal protocol CrashHandler: EventProperties {
 	var breadcrumbsSerialized: BreadcrumbStore.SerializedType? { get set }
-	func startCrashReporting(createdEvent: (event: Event) -> ())
+	func startCrashReporting(createdEvent: (generatedEvent: Event) -> ())
 }

--- a/Sources/Dictionary+Extras.swift
+++ b/Sources/Dictionary+Extras.swift
@@ -1,0 +1,25 @@
+//
+//  Dictionary+Extras.swift
+//  SentrySwift
+//
+//  Created by David Chavez on 25/05/16.
+//
+//
+
+import Foundation
+
+extension Dictionary {
+    internal mutating func unionInPlace(dictionary: Dictionary) {
+        dictionary.forEach { self.updateValue(self[$0] ?? $1, forKey: $0) }
+    }
+    
+    // Sets the key and value but only if value is non-nil
+    internal func set(key: Key, value: Value?) -> Dictionary<Key, Value> {
+        guard let value = value else { return self }
+        
+        var newDict = self
+        newDict[key] = value
+        
+        return newDict
+    }
+}

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -13,136 +13,11 @@ public typealias EventModules = [String: String]
 public typealias EventExtra = [String: AnyObject]
 public typealias EventFingerprint = [String]
 
-/// A struct to hold event properties
-@objc public class Event: NSObject, EventProperties {
-	
-	public static let platform = "cocoa"
-	
-	// MARK: Required
-	public let eventID: String = {
-		return NSUUID().UUIDString
-			.stringByReplacingOccurrencesOfString("-", withString: "")
-	}()
-	public var message: String
-	public var timestamp: NSDate = NSDate()
-	public var level: SentrySeverity = .Error
-	public var platform: String = Event.platform
-	
-	// MARK: Optional
-	public var logger: String?
-	public var culprit: String?
-	public var serverName: String?
-	public var releaseVersion: String?
-	public var tags: EventTags?
-	public var modules: EventModules?
-	public var extra: EventExtra?
-	public var fingerprint: EventFingerprint?
-	
-	public var user: User?
-	public var appleCrashReport: AppleCrashReport?
-	var breadcrumbsSerialized: BreadcrumbStore.SerializedType?
-	
-	public typealias BuildEvent = (inout Event) -> Void
-	
-	/// Creates an event
-	/// - Paramter message: A message
-	/// - Paramter build: A closure that passes an event to build upon
-	public static func build(message: String, build: BuildEvent) -> Event {
-		var event = Event(message, timestamp: NSDate())
-		build(&event)
-		return event
-	}
-	
-	/// Creates an event
-	/// - Paramter message: A message
-	/// - Paramter timestamp: A timestamp
-	/// - Paramter level: A severity level
-	/// - Paramter platform: A platform
-	/// - Paramter logger: A logger
-	/// - Paramter culprit: A culprit
-	/// - Paramter serverName: A server name
-	/// - Paramter release: A release
-	/// - Paramter tags: A dictionary of tags
-	/// - Paramter modules: A dictionary of modules
-	/// - Paramter extras: A dictionary of extras
-	/// - Paramter fingerprint: A array of fingerprints
-	/// - Paramter user: A user object
-	/// - Paramter appleCrashReport: An apple crash report
-	@objc public init(_ message: String, timestamp: NSDate = NSDate(), level: SentrySeverity = .Error, logger: String? = nil, culprit: String? = nil, serverName: String? = nil, release: String? = nil, tags: EventTags? = nil, modules: EventModules? = nil, extra: EventExtra? = nil, fingerprint: EventFingerprint? = nil, user: User? = nil, appleCrashReport: AppleCrashReport? = nil) {
-		
-		// Required
-		self.message = message
-		self.timestamp = timestamp
-		self.level = level
-		
-		// Optional
-		self.logger = logger
-		self.culprit = culprit
-		self.serverName = serverName
-		self.releaseVersion = release
-		self.tags = tags
-		self.modules = modules
-		self.extra = extra
-		self.fingerprint = fingerprint
-		
-		// Optional interfaces
-		self.user = user
-		self.appleCrashReport = appleCrashReport
-	}
-}
+// This is declared here to keep namespace compatibility with objc
+@objc public enum SentrySeverity: Int, CustomStringConvertible {
+	case Fatal, Error, Warning, Info, Debug
 
-extension Event: EventSerializable {
-	typealias Attribute = (key: String, value: AnyObject?)
-	
-	public typealias SerializedType = [String: AnyObject]
-	
-	/// A dictionary of attributes defined by this event
-	public var serialized: SerializedType {
-		
-		// Create attributes list
-		let attributes: [Attribute] = [
-			// Required
-			("event_id", eventID),
-			("message", message),
-			("timestamp", timestamp.iso8601),
-			("level", level.name),
-			("platform", platform),
-			
-			// Optional
-			("logger", logger),
-			("culprit", culprit),
-			("server_name", serverName),
-			("release", releaseVersion),
-			("tags", tags),
-			("modules", modules),
-			("extra", extra),
-			("fingerprint", fingerprint),
-			
-			// Interfaces
-			("user", user?.serialized),
-			("applecrashreport", appleCrashReport?.serialized),
-			("breadcrumbs", breadcrumbsSerialized)
-		]
-		
-		// Reduce attributes so only non-nill attribute are sent
-		return attributes.reduce(SerializedType()) { serializedType, attribute in
-			var output = serializedType
-			if let value = attribute.value {
-				output[attribute.key] = value
-			}
-			return output
-		}
-	}
-}
-
-@objc public enum SentrySeverity: Int {
-	case Fatal
-	case Error
-	case Warning
-	case Info
-	case Debug
-	
-	public var name: String {
+	public var description: String {
 		switch self {
 		case Fatal: return "fatal"
 		case Error: return "error"
@@ -153,22 +28,125 @@ extension Event: EventSerializable {
 	}
 }
 
-// MARK: Date
+/// A class that defines an event to be reported
+@objc public class Event: NSObject, EventProperties {
 
-private let dateFormatter: NSDateFormatter  = {
-	let df = NSDateFormatter()
-	df.locale = NSLocale(localeIdentifier: "en_US_POSIX")
-	df.timeZone = NSTimeZone(abbreviation: "UTC")
-	df.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-	return df
-}()
+	public typealias BuildEvent = (inout Event) -> Void
 
-extension NSDate {
-	public static func fromISO8601(iso8601String: String) -> NSDate? {
-		return dateFormatter.dateFromString(iso8601String)
+	// MARK: - Required Attributes
+
+	public let eventID: String = NSUUID().UUIDString.stringByReplacingOccurrencesOfString("-", withString: "")
+	public var message: String
+	public var timestamp: NSDate = NSDate()
+	public var level: SentrySeverity = .Error
+	public var platform: String = "cocoa"
+
+
+	// MARK: - Optional Attributes
+
+	public var logger: String?
+	public var culprit: String?
+	public var serverName: String?
+	public var releaseVersion: String?
+	public var tags: EventTags?
+	public var modules: EventModules?
+	public var extra: EventExtra?
+	public var fingerprint: EventFingerprint?
+
+
+	// MARK: - Optional Interfaces
+
+	public var user: User?
+	public var appleCrashReport: AppleCrashReport?
+	internal var breadcrumbsSerialized: BreadcrumbStore.SerializedType?
+
+	/*
+    Creates an event
+    - Paramter message: A message
+    - Paramter build: A closure that passes an event to build upon
+    */
+	public static func build(message: String, build: BuildEvent) -> Event {
+		var event: Event = Event(message, timestamp: NSDate())
+		build(&event)
+		return event
 	}
-	
-	public var iso8601: String {
-		return dateFormatter.stringFromDate(self)
+
+	/*
+    Creates an event
+    - Paramter message: A message
+    - Paramter timestamp: A timestamp
+    - Paramter level: A severity level
+    - Paramter platform: A platform
+    - Paramter logger: A logger
+    - Paramter culprit: A culprit
+    - Paramter serverName: A server name
+    - Paramter release: A release
+    - Paramter tags: A dictionary of tags
+    - Paramter modules: A dictionary of modules
+    - Paramter extras: A dictionary of extras
+    - Paramter fingerprint: A array of fingerprints
+    - Paramter user: A user object
+    - Paramter appleCrashReport: An apple crash report
+    */
+	@objc public init(_ message: String, timestamp: NSDate = NSDate(), level: SentrySeverity = .Error, logger: String? = nil, culprit: String? = nil, serverName: String? = nil, release: String? = nil, tags: EventTags? = [:], modules: EventModules? = nil, extra: EventExtra? = [:], fingerprint: EventFingerprint? = nil, user: User? = nil, appleCrashReport: AppleCrashReport? = nil) {
+
+		// Required
+		self.message = message
+		self.timestamp = timestamp
+		self.level = level
+
+		// Optional
+		self.logger = logger
+		self.culprit = culprit
+		self.serverName = serverName
+		self.releaseVersion = release
+		self.tags = tags
+		self.modules = modules
+		self.extra = extra
+		self.fingerprint = fingerprint
+
+		// Optional Interfaces
+		self.user = user
+		self.appleCrashReport = appleCrashReport
+
+		super.init()
+	}
+}
+
+extension Event: EventSerializable {
+	internal typealias SerializedType = SerializedTypeDictionary
+	internal typealias Attribute = (key: String, value: AnyObject?)
+
+	/// Dictionary version of attributes set in event
+	internal var serialized: SerializedType {
+
+		// Create attributes list
+		let attributes: [Attribute] = [
+			// Required
+			("event_id", eventID),
+			("message", message),
+			("timestamp", timestamp.iso8601),
+			("level", level.description),
+			("platform", platform),
+
+			// Optional
+			("logger", logger),
+			("culprit", culprit),
+			("server_name", serverName),
+			("release", releaseVersion),
+			("tags", tags),
+			("modules", modules),
+			("extra", extra),
+			("fingerprint", fingerprint),
+
+			// Interfaces
+			("user", user?.serialized),
+			("applecrashreport", appleCrashReport?.serialized),
+			("breadcrumbs", breadcrumbsSerialized)
+		]
+
+		var ret: [String: AnyObject] = [:]
+		attributes.filter() { $0.value != nil }.forEach() { ret.updateValue($0.value!, forKey: $0.key) }
+		return ret
 	}
 }

--- a/Sources/EventProperties.swift
+++ b/Sources/EventProperties.swift
@@ -8,35 +8,26 @@
 
 import Foundation
 
-private extension Dictionary {
-    mutating func mergeValues(from other: Dictionary<Key, Value>, overrideExisting: Bool = false) {
-        for k in other.keys {
-            if overrideExisting {
-                self[k] = other[k]
-            } else {
-                self[k] = self[k] ?? other[k]
-            }
-        }
-    }
-}
+/// Protocol defining common editable properties of Sentry client and Event
+internal protocol EventProperties {
 
-/// Properties that can be set globally on a SentryClient
-/// and on an Event.
-@objc public protocol EventProperties {
-	// Attributes
+	// MARK: - Attributes
 	var tags: EventTags? { get set }
 	var extra: EventExtra? { get set }
 	
-	// Interfaces
+	// MARK: - Interfaces
 	var user: User? { get set }
 }
 
 extension EventProperties {
-	/// Merges event properties into self. Only values not set in the receiver are set. Dictionary properties are merged non-recursively, preferring the values in the receiver.
-	/// - Parameter eventProperties: Event properties to merge on self
-	public func mergeProperties(eventProperties: EventProperties) {
-        tags?.mergeValues(from: eventProperties.tags ?? [:])
-        extra?.mergeValues(from: eventProperties.extra ?? [:])
-        user = user ?? eventProperties.user
-	}
+
+    /*
+    Merges another EventProperties into this. Will only replace non-existing keys.
+    - Parameter from: EventProperties to merge
+    */
+    internal mutating func mergeProperties(from other: EventProperties) {
+        tags?.unionInPlace(other.tags ?? [:])
+        extra?.unionInPlace(other.extra ?? [:])
+        user = user ?? other.user
+    }
 }

--- a/Sources/EventSerializable.swift
+++ b/Sources/EventSerializable.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-public typealias SerializedTypeDictionary = [String: AnyObject]
-public typealias SerializedTypeArray = [SerializedTypeDictionary]
+internal typealias SerializedTypeDictionary = [String: AnyObject]
+internal typealias SerializedTypeArray = [SerializedTypeDictionary]
 
 /// A protocol used for complex structures (ex: Event, User, AppleCrashReport)
 /// on how to serialize them.
-public protocol EventSerializable {
+internal protocol EventSerializable {
 	associatedtype SerializedType
 	var serialized: SerializedType { get }
 }

--- a/Sources/NSDate+Extras.swift
+++ b/Sources/NSDate+Extras.swift
@@ -1,0 +1,29 @@
+//
+//  NSDate+Extras.swift
+//  SentrySwift
+//
+//  Created by David Chavez on 25/05/16.
+//
+//
+
+import Foundation
+
+// MARK: - NSDate
+
+private let dateFormatter: NSDateFormatter  = {
+    let df = NSDateFormatter()
+    df.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+    df.timeZone = NSTimeZone(abbreviation: "UTC")
+    df.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+    return df
+}()
+
+extension NSDate {
+    internal static func fromISO8601(iso8601String: String) -> NSDate? {
+        return dateFormatter.dateFromString(iso8601String)
+    }
+    
+    internal var iso8601: String {
+        return dateFormatter.stringFromDate(self)
+    }
+}

--- a/Sources/User.swift
+++ b/Sources/User.swift
@@ -10,50 +10,45 @@ import Foundation
 
 /// A class used to represent the user attached to events
 @objc public class User: NSObject {
-	public var userID: String
-	public var email: String?
-	public var username: String?
-	public var extra: [String: AnyObject]?
-	
-	/// Creates a user
-	/// - Parameter userID: A user id
-	/// - Parameter email: An optional email
-	/// - Parameter username: An optional username
-	/// - Parameter extra: An optional extra dictionary
-	public init(id userID: String, email: String? = nil, username: String? = nil, extra: [String: AnyObject]? = nil) {
-		self.userID = userID
-		self.email = email
-		self.username = username
-		self.extra = extra
-	}
-	
-	/// Creates a user from a dictionary
-	/// This will mostly get used from a saved offline event
-	/// - Parameter dictionary: A dictionary of data to parse to fill properties of a user
-	public convenience init?(dictionary: [String: AnyObject]?) {
-		guard let dictionary = dictionary, userID = dictionary["id"] as? String else { return nil }
-		self.init(
-			id: userID,
-			email: dictionary["email"] as? String,
-			username: dictionary["username"] as? String,
-			extra: dictionary
-		)
-	}
+    public var userID: String
+    public var email: String?
+    public var username: String?
+    public var extra: [String: AnyObject]
+
+    /// Creates a user
+    /// - Parameter userID: A user id
+    /// - Parameter email: An optional email
+    /// - Parameter username: An optional username
+    /// - Parameter extra: An optional extra dictionary
+    @objc public init(id userID: String, email: String? = nil, username: String? = nil, extra: [String: AnyObject] = [:]) {
+        self.userID = userID
+        self.email = email
+        self.username = username
+        self.extra = extra
+
+        super.init()
+    }
+
+    /// Creates a user from a dictionary
+    /// This will mostly get used from a saved offline event
+    /// - Parameter dictionary: A dictionary of data to parse to fill properties of a user
+    internal convenience init?(dictionary: [String: AnyObject]?) {
+        guard let dictionary = dictionary, userID = dictionary["id"] as? String else { return nil }
+        self.init(
+        id: userID,
+                email: dictionary["email"] as? String,
+                username: dictionary["username"] as? String,
+                extra: dictionary
+        )
+    }
 }
 
 extension User: EventSerializable {
-	public typealias SerializedType = SerializedTypeDictionary
-	public var serialized: SerializedType {
-		var info = extra ?? [String: AnyObject]()
-		info["id"] = userID
-		
-		if let email = email {
-			info["email"] = email
-		}
-		if let username = username {
-			info["username"] = username
-		}
-		
-		return info
-	}
+    internal typealias SerializedType = SerializedTypeDictionary
+    internal var serialized: SerializedType {
+        return extra
+            .set("id", value: userID)
+            .set("email", value: email)
+            .set("username", value: username)
+    }
 }


### PR DESCRIPTION
Hey guys,

As a big user of Sentry, I was patiently waiting for the new SDK to be out and now it is! 🎉 However, in my project I had some issues. Mostly around namespacing, I went in to fix the issues and in there thought some things could be improved:

- There's now better namespacing! Almost all classes/structs will fall under the `Sentry` namespace.  It works really well with Swift though somethings couldn't be moved because of the required interoperability with objc.
- I've now explicitly set access-control. There was many things that were public that probably shouldn't have been. There was also a divergence in code style (probably because of different people working on it).
- 47c463ba6b10df46da752eeac7ec41a7bd79e483 broke compatibility with `Breadcrumbs` in objc; however, it wasn't caught because objc test weren't testing for it. Now they are and the objc example also has them :) That same commit also raised other issues which I've addressed as in-line comments in this PR.

It's a big PR so let me know if there's any issues :)