### PR TITLE
[WIP] merging empty events

### DIFF
--- a/SentrySwiftTests/SentrySwiftTests.swift
+++ b/SentrySwiftTests/SentrySwiftTests.swift
@@ -306,6 +306,56 @@ class SentrySwiftTests: XCTestCase {
 		assert(event.user!.email! == "stuff@example.com")
 		assert(event.user!.username! == "stuff")
 	}
+
+    func testMergeEmptyEvent() {
+        let client = SentryClient(dsnString: "https://username:password@app.getsentry.com/12345")!
+
+        let testTags = ["test": "foo"]
+        let testExtra = ["bar": "baz"]
+        let testUser = User(id: "3", email: "things@example.com", username: "things")
+
+        client.tags = testTags
+        client.extra = testExtra
+        client.user = testUser
+
+        let event = Event("such event")
+
+        assert(event.tags == nil)
+        assert(event.extra == nil)
+        assert(event.user == nil)
+
+        event.mergeProperties(client)
+        assert(event.tags! == testTags)
+        assert(event.extra! == testExtra)
+        assert(event.user!.userID == testUser.userID)
+        assert(event.user!.email! == testUser.email!)
+        assert(event.user!.username! == testUser.username!)
+    }
+
+    func testMergeEmptyClient() {
+        let client = SentryClient(dsnString: "https://username:password@app.getsentry.com/12345")!
+
+        assert(client.tags == nil)
+        assert(client.extra == nil)
+        assert(client.user == nil)
+
+        let testTags = ["test": "foo"]
+        let testExtra = ["bar": "baz"]
+        let testUser = User(id: "3", email: "things@example.com", username: "things")
+
+        let event = Event("such event")
+
+        event.tags = testTags
+        event.extra = testExtra
+        event.user = testUser
+
+        event.mergeProperties(client)
+        assert(event.tags! == testTags)
+        assert(event.extra! == testExtra)
+        assert(event.user!.userID == testUser.userID)
+        assert(event.user!.email! == testUser.email!)
+        assert(event.user!.username! == testUser.username!)
+    }
 }
 
 /// A small hack to compare dictionaries


### PR DESCRIPTION
I broke merging an empty event in #11. This adds a (currently failing) test for that and is supposed to act as a reminder for me to fix this.

@joshdholtz do you still agree with making `tags` and `extra` non-optional and default to `[:]`?