### PR TITLE
truncate culprit

### DIFF
--- a/SentrySwiftTests/SentrySwiftTests.swift
+++ b/SentrySwiftTests/SentrySwiftTests.swift
@@ -247,6 +247,23 @@ class SentrySwiftTests: XCTestCase {
 		assert(serialized["extra"] as! EventExtra == extra)
 		assert(serialized["fingerprint"] as! EventFingerprint == fingerprint)
 	}
+
+    func testEventTruncatesCulprit() {
+        let shortString = String(count: 200, repeatedValue: Character("-"))
+        let longString = String(count: 201, repeatedValue: Character("-"))
+
+        let shortEvent = Event("test", culprit: shortString)
+        let longEvent = Event("test", culprit: longString)
+
+        let ss = shortEvent.serialized
+        let ls = longEvent.serialized
+
+        assert(ss["culprit"] as! String == shortString)
+        assert(ss["extra"]?["__full_culprit"] == nil)
+
+        assert(ls["culprit"] as! String == shortString) // note this compares to shortString
+        assert(ls["extra"]!["__full_culprit"]! == longString)
+    }
 	
 	// MARK: EventProperties
 	

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -98,6 +98,17 @@ extension Event: EventSerializable {
 	
 	/// A dictionary of attributes defined by this event
 	public var serialized: SerializedType {
+
+        var modifiedExtra = extra
+
+        var truncatedCulprit: String? = nil
+        if let culprit = culprit where culprit.characters.count > 200 {
+            truncatedCulprit = culprit.substringToIndex(culprit.startIndex.advancedBy(200, limit: culprit.endIndex))
+            modifiedExtra = modifiedExtra ?? [:]
+                // need to force-unwrap because assigning into a if var would just 
+                // write into a shadowing copy
+            modifiedExtra!["__full_culprit"] = culprit
+        }
 		
 		// Create attributes list
 		let attributes: [Attribute] = [
@@ -110,12 +121,12 @@ extension Event: EventSerializable {
 			
 			// Optional
 			("logger", logger),
-			("culprit", culprit),
+			("culprit", truncatedCulprit ?? culprit),
 			("server_name", serverName),
 			("release", releaseVersion),
 			("tags", tags),
 			("modules", modules),
-			("extra", extra),
+			("extra", modifiedExtra),
 			("fingerprint", fingerprint),
 			
 			// Interfaces


### PR DESCRIPTION
This will truncate the culprit to 200 characters and send it in extra if necessary. This is a first step towards fixing #17.