### PR TITLE
Fix crash when setting non-JSON conforming attributes

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -52,9 +52,9 @@ public typealias EventFingerprint = [String]
 	public var culprit: String?
 	public var serverName: String?
 	public var releaseVersion: String?
-	public var tags: EventTags?
+	public var tags: EventTags = [:]
 	public var modules: EventModules?
-	public var extra: EventExtra?
+	public var extra: EventExtra = [:]
 	public var fingerprint: EventFingerprint?
 
 
@@ -94,7 +94,7 @@ public typealias EventFingerprint = [String]
 	- Parameter exception: An array of `Exception` objects
 	- Parameter appleCrashReport: An apple crash report
 	*/
-	@objc public init(_ message: String, timestamp: NSDate = NSDate(), level: SentrySeverity = .Error, logger: String? = nil, culprit: String? = nil, serverName: String? = nil, release: String? = nil, tags: EventTags? = nil, modules: EventModules? = nil, extra: EventExtra? = nil, fingerprint: EventFingerprint? = nil, user: User? = nil, exception: [Exception]? = nil, appleCrashReport: AppleCrashReport? = nil) {
+	@objc public init(_ message: String, timestamp: NSDate = NSDate(), level: SentrySeverity = .Error, logger: String? = nil, culprit: String? = nil, serverName: String? = nil, release: String? = nil, tags: EventTags = [:], modules: EventModules? = nil, extra: EventExtra = [:], fingerprint: EventFingerprint? = nil, user: User? = nil, exception: [Exception]? = nil, appleCrashReport: AppleCrashReport? = nil) {
 
 		// Required
 		self.message = message
@@ -185,9 +185,9 @@ extension Event: EventSerializable {
 			("culprit", culprit),
 			("server_name", serverName),
 			("release", releaseVersion),
-			("tags", tags),
+			("tags", NSJSONSerialization.isValidJSONObject(tags) ? tags : nil),
 			("modules", modules),
-			("extra", extra),
+			("extra", NSJSONSerialization.isValidJSONObject(extra) ? extra : nil),
 			("fingerprint", fingerprint),
 
 			// Interfaces

--- a/Sources/EventOffline.swift
+++ b/Sources/EventOffline.swift
@@ -85,7 +85,11 @@ extension SentryClient {
 	- Returns: Serialized string
 	*/
 	private func serializedString(event: Event) throws -> String? {
-		let data: NSData = try NSJSONSerialization.dataWithJSONObject(event.serialized, options: [])
-		return String(data: data, encoding: NSUTF8StringEncoding)
+		if NSJSONSerialization.isValidJSONObject(event.serialized) {
+			let data: NSData = try NSJSONSerialization.dataWithJSONObject(event.serialized, options: [])
+			return String(data: data, encoding: NSUTF8StringEncoding)
+		}
+
+		return nil
 	}
 }

--- a/Sources/EventProperties.swift
+++ b/Sources/EventProperties.swift
@@ -12,26 +12,9 @@ import Foundation
 internal protocol EventProperties {
 
 	// MARK: - Attributes
-	var tags: EventTags? { get set }
-	var extra: EventExtra? { get set }
+	var tags: EventTags { get set }
+	var extra: EventExtra { get set }
 	
 	// MARK: - Interfaces
 	var user: User? { get set }
-}
-
-extension EventProperties {
-
-    /*
-    Merges another EventProperties into this. Will only replace non-existing keys.
-    - Parameter from: EventProperties to merge
-    */
-    internal mutating func mergeProperties(from other: EventProperties) {
-		// Cannot merge on nil dictionaries
-		tags = tags ?? [:]
-		extra = extra ?? [:]
-		
-        tags?.unionInPlace(other.tags ?? [:])
-        extra?.unionInPlace(other.extra ?? [:])
-        user = user ?? other.user
-    }
 }

--- a/Sources/KSCrashHandler.swift
+++ b/Sources/KSCrashHandler.swift
@@ -44,10 +44,10 @@ internal class KSCrashHandler: CrashHandler {
 
 	// MARK: - EventProperties
 
-	internal var tags: EventTags? {
+	internal var tags: EventTags = [:] {
 		didSet { updateUserInfo() }
 	}
-	internal var extra: EventExtra? {
+	internal var extra: EventExtra = [:] {
 		didSet { updateUserInfo() }
 	}
 	internal var user: User? {
@@ -130,8 +130,8 @@ internal class KSCrashHandler: CrashHandler {
 				let event = Event.build("") {
 					$0.level = .Fatal
 					$0.timestamp = timestamp
-					$0.tags = userInfo.tags
-					$0.extra = userInfo.extra
+					$0.tags = userInfo.tags ?? [:]
+					$0.extra = userInfo.extra ?? [:]
 					$0.user = userInfo.user
 					$0.appleCrashReport = appleCrashReport
 					$0.breadcrumbsSerialized = userInfo.breadcrumbsSerialized
@@ -148,15 +148,11 @@ internal class KSCrashHandler: CrashHandler {
 
 	private func updateUserInfo() {
 		var userInfo = CrashDictionary()
+		userInfo[keyEventTags] = tags
+		userInfo[keyEventExtra] = extra
 
 		if let user = user?.serialized {
 			userInfo[keyUser] = user
-		}
-		if let tags = tags {
-			userInfo[keyEventTags] = tags
-		}
-		if let extra = extra {
-			userInfo[keyEventExtra] = extra
 		}
 
 		if let breadcrumbsSerialized = breadcrumbsSerialized {

--- a/Sources/Request.swift
+++ b/Sources/Request.swift
@@ -18,11 +18,11 @@ extension SentryClient {
 	- Parameter finished: A closure with the success status
 	*/
 	internal func sendEvent(event: Event, finished: EventFinishedSending? = nil) {
-		do {
-			let data: NSData = try NSJSONSerialization.dataWithJSONObject(event.serialized, options: [])
-			sendData(data, finished: finished)
-		} catch {
-			return
+		if NSJSONSerialization.isValidJSONObject(event.serialized) {
+			do {
+				let data: NSData = try NSJSONSerialization.dataWithJSONObject(event.serialized, options: [])
+				sendData(data, finished: finished)
+			} catch {}
 		}
 	}
 	


### PR DESCRIPTION
Fixes #33 

This fixes the immediate problem of the app crashing.. however, this should not be the long term fix. We don't convey in any way to the user that the dictionaries they use for extras/tags are supposed to be JSON mappable... it's also bad if users are setting some weird things in their tags and now their events are not being reported because the serialization is failing.

so we should either convey this through a custom type/documentation or we should find a way to sanitize the values. I prefer latter because I find it weird for the user to have to sanitize their own dictionaries. we could also possibly just drop the failing part but still send the event (probably best option as the user would be missing info, but not the whole event)

however, I'd say let's merge this to fix the immediate problem then i can make a PR with a fix (which may take longer)

**Ammend:**
I've now added functionality to where, if one of the tags or extras will fail serialization, we'll just exclude it from the event. That way users will still get alerted about errors; however, it will unfortunately not contain all the info they wanted.

I've also removed the `mergeProperties` method and made tags and extra default to `[:]`. The defaulting tags to `[:]` was because we always run the `mergeProperties` which basically was doing that, defaulting it to `[:]` it's more clear to do it at the model level.

About removing `mergeProperties` I don't think it makes sense to have that be an abstracted part, I think we should manually be merging objects wherever we need to merge them.. (i.e. reportEvent) and it was hard to maintain while fixing the crash problem..