### PR TITLE
Pass release on to the sentry-server

### DIFF
--- a/SentrySwift.xcodeproj/project.pbxproj
+++ b/SentrySwift.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		03FF07C61CE545D300BA980E /* SentrySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035242971C988D2F00A65D6D /* SentrySwiftTests.swift */; };
 		03FF07C71CE545D300BA980E /* SentrySwiftBreadcrumbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D4D9FF1CA586EF00799CC9 /* SentrySwiftBreadcrumbTests.swift */; };
 		03FF07C81CE546B500BA980E /* Abort.json in Resources */ = {isa = PBXBuildFile; fileRef = 035242941C988D2F00A65D6D /* Abort.json */; };
+		43FF9A3D1D12127E000B0F9A /* SentryClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FF9A3C1D12127E000B0F9A /* SentryClientTests.swift */; };
+		43FF9A3E1D12127E000B0F9A /* SentryClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FF9A3C1D12127E000B0F9A /* SentryClientTests.swift */; };
+		43FF9A3F1D12127E000B0F9A /* SentryClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FF9A3C1D12127E000B0F9A /* SentryClientTests.swift */; };
 		9B02CAB71CF5C20F004F614C /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */; };
 		9B02CAB81CF5C20F004F614C /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */; };
 		9B02CAB91CF5C20F004F614C /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */; };
@@ -217,6 +220,7 @@
 		03E94AF61C22595C009F8F29 /* SentrySwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SentrySwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03E94B0B1C22596A009F8F29 /* SentrySwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SentrySwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		03E94B141C22596A009F8F29 /* SentrySwift-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SentrySwift-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		43FF9A3C1D12127E000B0F9A /* SentryClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryClientTests.swift; sourceTree = "<group>"; };
 		9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
 		9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Extras.swift"; sourceTree = "<group>"; };
 		9B02CAFD1CF607A5004F614C /* Exception.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exception.swift; sourceTree = "<group>"; };
@@ -303,6 +307,7 @@
 				035C4E6B1CA044060082B5EA /* SentrySwiftObjCTests.h */,
 				035C4E6C1CA044060082B5EA /* SentrySwiftObjCTests.m */,
 				035C4E6A1CA044060082B5EA /* SentrySwiftTests-Bridging-Header.h */,
+				43FF9A3C1D12127E000B0F9A /* SentryClientTests.swift */,
 			);
 			path = SentrySwiftTests;
 			sourceTree = "<group>";
@@ -786,6 +791,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				03FF07C71CE545D300BA980E /* SentrySwiftBreadcrumbTests.swift in Sources */,
+				43FF9A3F1D12127E000B0F9A /* SentryClientTests.swift in Sources */,
 				03FF07C61CE545D300BA980E /* SentrySwiftTests.swift in Sources */,
 				03FF07C51CE545D300BA980E /* SentrySwiftCrashTests.swift in Sources */,
 			);
@@ -819,6 +825,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				03D4DA001CA586EF00799CC9 /* SentrySwiftBreadcrumbTests.swift in Sources */,
+				43FF9A3D1D12127E000B0F9A /* SentryClientTests.swift in Sources */,
 				035242A91C98957C00A65D6D /* SentrySwiftTests.swift in Sources */,
 				035242A81C98957800A65D6D /* SentrySwiftCrashTests.swift in Sources */,
 			);
@@ -855,6 +862,7 @@
 				035242A61C9892A700A65D6D /* SentrySwiftCrashTests.swift in Sources */,
 				03D4DA011CA586EF00799CC9 /* SentrySwiftBreadcrumbTests.swift in Sources */,
 				035C4E711CA044A10082B5EA /* SentrySwiftObjCTests.m in Sources */,
+				43FF9A3E1D12127E000B0F9A /* SentryClientTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SentrySwiftTests/SentryClientTests.swift
+++ b/SentrySwiftTests/SentryClientTests.swift
@@ -1,0 +1,65 @@
+//
+//  SentryClientTests.swift
+//  SentrySwift
+//
+//  Created by Benjamin Horsleben on 16/06/16.
+//
+//
+
+import Foundation
+import XCTest
+@testable import SentrySwift
+
+class TestCrashHandler:CrashHandler {
+	required init(client: SentryClient) {
+	}
+
+	var crashReportingHasStarted = false
+	func startCrashReporting() {
+		crashReportingHasStarted = true
+	}
+
+	var breadcrumbsSerialized: BreadcrumbStore.SerializedType?
+	var releaseVersion: String?
+	var tags: EventTags = [:]
+	var extra: EventExtra = [:]
+	var user: User?
+}
+
+class TestableSentryClient: SentryClient {
+	var dataToSend:[(data:NSData, callback:EventFinishedSending?)] = []
+	override func sendData(data: NSData, finished: EventFinishedSending?) {
+		// Do nothing. The original sends data to the server
+
+		dataToSend.append((data, finished))
+	}
+}
+
+class SentryClientTests: XCTestCase {
+	var client:SentryClient!
+	override func setUp() {
+		super.setUp()
+
+		let dsn = DSN(dsn: NSURL(), serverURL: NSURL(), publicKey: nil, secretKey: nil, projectID: "some project")
+		client = TestableSentryClient(dsn: dsn)
+	}
+
+	func test_setReleaseVersion_crashHandlerIsPresent_releaseVersionIsPassedOnToCrashHandler() {
+		let crashHandler = TestCrashHandler(client: client)
+		client.crashHandler = crashHandler
+
+		let releaseVersion = "1.2.3"
+		client.releaseVersion = releaseVersion
+
+		XCTAssertEqual(releaseVersion, client.releaseVersion)
+		XCTAssertEqual(releaseVersion, crashHandler.releaseVersion)
+	}
+
+	func test_setReleaseVersion_crashHandlerIsNotSet_releaseVersionIsOnlySetOnClient() {
+		let releaseVersion = "1.2.3"
+		client.releaseVersion = releaseVersion
+
+		XCTAssertEqual(releaseVersion, client.releaseVersion)
+		XCTAssertNil(client.crashHandler)
+	}
+}

--- a/Sources/EventProperties.swift
+++ b/Sources/EventProperties.swift
@@ -12,6 +12,7 @@ import Foundation
 internal protocol EventProperties {
 
 	// MARK: - Attributes
+	var releaseVersion: String? { get set }
 	var tags: EventTags { get set }
 	var extra: EventExtra { get set }
 	

--- a/Sources/KSCrashHandler.swift
+++ b/Sources/KSCrashHandler.swift
@@ -21,6 +21,7 @@ private let keyUser = "user"
 private let keyEventTags = "event_tags"
 private let keyEventExtra = "event_extra"
 private let keyBreadcrumbsSerialized = "breadcrumbs_serialized"
+private let keyReleaseVersion = "releaseVersion_serialized"
 
 
 /// A class to report crashes to Sentry built upon KSCrash
@@ -35,6 +36,9 @@ internal class KSCrashHandler: CrashHandler {
 
 	// MARK: - EventProperties
 
+	internal var releaseVersion: String? {
+		didSet { updateUserInfo() }
+	}
 	internal var tags: EventTags = [:] {
 		didSet { updateUserInfo() }
 	}
@@ -84,6 +88,7 @@ internal class KSCrashHandler: CrashHandler {
 		var userInfo = CrashDictionary()
 		userInfo[keyEventTags] = tags
 		userInfo[keyEventExtra] = extra
+		userInfo[keyReleaseVersion] = releaseVersion
 
 		if let user = user?.serialized {
 			userInfo[keyUser] = user
@@ -188,17 +193,19 @@ private class KSCrashReportSinkSentry: NSObject, KSCrashReportFilter {
 			$0.user = userInfo.user
 			$0.appleCrashReport = appleCrashReport
 			$0.breadcrumbsSerialized = userInfo.breadcrumbsSerialized
+			$0.releaseVersion = userInfo.releaseVersion
 		}
 		
 		return event
 	}
 	
-	private func parseUserInfo(userInfo: CrashDictionary?) -> (tags: EventTags?, extra: EventExtra?, user: User?, breadcrumbsSerialized: BreadcrumbStore.SerializedType?) {
+	private func parseUserInfo(userInfo: CrashDictionary?) -> (tags: EventTags?, extra: EventExtra?, user: User?, breadcrumbsSerialized: BreadcrumbStore.SerializedType?, releaseVersion:String?) {
 		return (
 			userInfo?[keyEventTags] as? EventTags,
 			userInfo?[keyEventExtra] as? EventExtra,
 			User(dictionary: userInfo?[keyUser] as? [String: AnyObject]),
-			userInfo?[keyBreadcrumbsSerialized] as? BreadcrumbStore.SerializedType
+			userInfo?[keyBreadcrumbsSerialized] as? BreadcrumbStore.SerializedType,
+			userInfo?[keyReleaseVersion] as? String
 		)
 	}
 	

--- a/Sources/Sentry.swift
+++ b/Sources/Sentry.swift
@@ -62,6 +62,9 @@ import Foundation
 
 	// MARK: EventProperties
 
+	public var releaseVersion: String? {
+		didSet { crashHandler?.releaseVersion = releaseVersion }
+	}
 	public var tags: EventTags = [:] {
 		didSet { crashHandler?.tags = tags }
 	}
@@ -113,6 +116,7 @@ import Foundation
 		// Don't allow client attributes to be used when reporting an `Exception`
 		if useClientProperties && event.level != .Fatal {
 			event.user = event.user ?? user
+			event.releaseVersion = event.releaseVersion ?? releaseVersion
 
 			if NSJSONSerialization.isValidJSONObject(tags) {
 				event.tags.unionInPlace(tags)


### PR DESCRIPTION
The `Event` class had support for a ReleaseVersion string, but there was no way to set it outside of calling `SentryClient.captureEvent(_:)`.

I have added it as an ivar to `SentryClient`, so that it will be sent automatically in case of crashes.