### PR TITLE
Fixes for release and contexts

### DIFF
--- a/SentrySwiftTests/SentrySwiftTests.swift
+++ b/SentrySwiftTests/SentrySwiftTests.swift
@@ -216,7 +216,7 @@ class SentrySwiftTests: XCTestCase {
 		XCTAssertEqual(sdk["version"], SentryClient.Info.version)
 		
 		// Device
-		let context = serialized["context"] as! [String: AnyObject]
+		let context = serialized["contexts"] as! [String: AnyObject]
 		XCTAssertNotNil(context["os"])
 		XCTAssertNotNil(context["device"])
 		

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -148,7 +148,7 @@ extension Event: EventSerializable {
 			
 			// Computed
 			("sdk", sdk),
-			("context", Context().serialized),
+			("contexts", Context().serialized),
 
 			// Optional
 			("logger", logger),

--- a/Sources/Sentry.swift
+++ b/Sources/Sentry.swift
@@ -41,7 +41,7 @@ internal enum SentryError: ErrorType {
 	// MARK: - Enums
 
 	internal struct Info {
-		static let version: String = "0.3.1"
+		static let version: String = "0.3.2"
 		static let sentryVersion: Int = 7
 	}
 
@@ -52,6 +52,10 @@ internal enum SentryError: ErrorType {
 	internal(set) var crashHandler: CrashHandler? {
 		didSet {
 			crashHandler?.startCrashReporting()
+			crashHandler?.releaseVersion = releaseVersion
+			crashHandler?.tags = tags
+			crashHandler?.extra = extra
+			crashHandler?.user = user
 		}
 	}
 	


### PR DESCRIPTION
- Release was not getting sent up on crashes
- Contexts was getting sent up on wrong key

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-swift/52)
<!-- Reviewable:end -->
