### PR TITLE
Sanitize Dictionary Entries

### DIFF
--- a/SentrySwift.xcodeproj/project.pbxproj
+++ b/SentrySwift.xcodeproj/project.pbxproj
@@ -193,6 +193,14 @@
 		9B02CAFE1CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
 		9B02CAFF1CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
 		9B02CB001CF607A5004F614C /* Exception.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B02CAFD1CF607A5004F614C /* Exception.swift */; };
+		9BF8E8091E3B5B6900A417AE /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8E8081E3B5B6900A417AE /* Functions.swift */; };
+		9BF8E80A1E3B5B6900A417AE /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8E8081E3B5B6900A417AE /* Functions.swift */; };
+		9BF8E80B1E3B5B6900A417AE /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8E8081E3B5B6900A417AE /* Functions.swift */; };
+		9BF8E80C1E3B5B6900A417AE /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8E8081E3B5B6900A417AE /* Functions.swift */; };
+		9BF8E8211E3B5C9400A417AE /* NSNumber+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8E8201E3B5C9400A417AE /* NSNumber+Extras.swift */; };
+		9BF8E8221E3B5C9400A417AE /* NSNumber+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8E8201E3B5C9400A417AE /* NSNumber+Extras.swift */; };
+		9BF8E8231E3B5C9400A417AE /* NSNumber+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8E8201E3B5C9400A417AE /* NSNumber+Extras.swift */; };
+		9BF8E8241E3B5C9400A417AE /* NSNumber+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8E8201E3B5C9400A417AE /* NSNumber+Extras.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -403,6 +411,8 @@
 		9B02CAB61CF5C20F004F614C /* Dictionary+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
 		9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Extras.swift"; sourceTree = "<group>"; };
 		9B02CAFD1CF607A5004F614C /* Exception.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exception.swift; sourceTree = "<group>"; };
+		9BF8E8081E3B5B6900A417AE /* Functions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
+		9BF8E8201E3B5C9400A417AE /* NSNumber+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSNumber+Extras.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -520,6 +530,7 @@
 		036378271C225D5200644C01 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				9BF8E8011E3B5B5100A417AE /* Utils */,
 				037061841C7615950082CCCE /* CrashHelper */,
 				9B02CAB11CF5C1E8004F614C /* Extensions */,
 				037061831C7615760082CCCE /* Interfaces */,
@@ -732,8 +743,17 @@
 			isa = PBXGroup;
 			children = (
 				9B02CABB1CF5C270004F614C /* NSDate+Extras.swift */,
+				9BF8E8201E3B5C9400A417AE /* NSNumber+Extras.swift */,
 			);
 			name = Foundation;
+			sourceTree = "<group>";
+		};
+		9BF8E8011E3B5B5100A417AE /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				9BF8E8081E3B5B6900A417AE /* Functions.swift */,
+			);
+			name = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1201,10 +1221,12 @@
 				63CDABA41DDF09EC00B63921 /* UserFeedback.swift in Sources */,
 				03C715261CE4DB8D0080AE60 /* Request.swift in Sources */,
 				03C7152F1CE4DB980080AE60 /* CrashHandler.swift in Sources */,
+				9BF8E80B1E3B5B6900A417AE /* Functions.swift in Sources */,
 				63571E951DFAAD42001924CD /* Frame.swift in Sources */,
 				630271C81E37701E0047DC3B /* Register.swift in Sources */,
 				03C715251CE4DB8D0080AE60 /* DSN.swift in Sources */,
 				03C715321CE4DBAE0080AE60 /* KSCrashHandler.swift in Sources */,
+				9BF8E8231E3B5C9400A417AE /* NSNumber+Extras.swift in Sources */,
 				03C7152D1CE4DB940080AE60 /* User.swift in Sources */,
 				03C715291CE4DB910080AE60 /* EventProperties.swift in Sources */,
 				6324960D1DEC33EE0014A044 /* SentrySwizzle.swift in Sources */,
@@ -1240,6 +1262,7 @@
 				63D54E5C1E0A7D790005B07A /* RequestOperation.swift in Sources */,
 				63D54E671E0A7F680005B07A /* RequestManager.swift in Sources */,
 				03E3D21F1C3EB20F00F00547 /* Request.swift in Sources */,
+				9BF8E8211E3B5C9400A417AE /* NSNumber+Extras.swift in Sources */,
 				0363782C1C225D8300644C01 /* Sentry.swift in Sources */,
 				03D4D9F91CA48FA800799CC9 /* Breadcrumb.swift in Sources */,
 				9B02CAB71CF5C20F004F614C /* Dictionary+Extras.swift in Sources */,
@@ -1255,6 +1278,7 @@
 				03E3D1F81C3E1A2800F00547 /* DSN.swift in Sources */,
 				033A342C1C60693400BED5AE /* User.swift in Sources */,
 				63CDABA31DDF09EC00B63921 /* UserFeedback.swift in Sources */,
+				9BF8E8091E3B5B6900A417AE /* Functions.swift in Sources */,
 				9B02CABC1CF5C270004F614C /* NSDate+Extras.swift in Sources */,
 				036378321C227C7900644C01 /* Event.swift in Sources */,
 				03B07DC31D089B23007B4758 /* KSCrashHandler.swift in Sources */,
@@ -1289,6 +1313,7 @@
 				03817D7F1D301E1D005A674A /* Contexts.swift in Sources */,
 				03C736E21C474715004428DF /* CrashHandler.swift in Sources */,
 				9B02CAB81CF5C20F004F614C /* Dictionary+Extras.swift in Sources */,
+				9BF8E8221E3B5C9400A417AE /* NSNumber+Extras.swift in Sources */,
 				63D54E5D1E0A7D790005B07A /* RequestOperation.swift in Sources */,
 				6350F6741DCE2F0900B6B596 /* CrashReportConverter.swift in Sources */,
 				033A342A1C605B7E00BED5AE /* EventProperties.swift in Sources */,
@@ -1311,6 +1336,7 @@
 				03E3D1F91C3E1A2800F00547 /* DSN.swift in Sources */,
 				63571EED1DFE99E6001924CD /* BinaryImage.swift in Sources */,
 				036378331C227C7900644C01 /* Event.swift in Sources */,
+				9BF8E80A1E3B5B6900A417AE /* Functions.swift in Sources */,
 				03A89AA21CAACA6F00D94E22 /* BreadcrumbStore.swift in Sources */,
 				632496061DEC33EA0014A044 /* SentrySwizzle.swift in Sources */,
 				63CDAB8D1DDCAAE700B63921 /* SentryEndpoint.swift in Sources */,
@@ -1353,6 +1379,7 @@
 				63D54E5F1E0A7D790005B07A /* RequestOperation.swift in Sources */,
 				63D54E6A1E0A7F680005B07A /* RequestManager.swift in Sources */,
 				63CDAB2F1DD9D4A000B63921 /* EventOffline.swift in Sources */,
+				9BF8E8241E3B5C9400A417AE /* NSNumber+Extras.swift in Sources */,
 				63CDAB381DD9D4A800B63921 /* Stacktrace.swift in Sources */,
 				63CDAB2B1DD9D48E00B63921 /* Request.swift in Sources */,
 				63CDAB391DD9D4A800B63921 /* Thread.swift in Sources */,
@@ -1368,6 +1395,7 @@
 				63CDAB281DD9D48500B63921 /* Sentry.swift in Sources */,
 				63CDABA51DDF09ED00B63921 /* UserFeedback.swift in Sources */,
 				63CDAB361DD9D4A800B63921 /* BreadcrumbStore.swift in Sources */,
+				9BF8E80C1E3B5B6900A417AE /* Functions.swift in Sources */,
 				63CDAB341DD9D4A800B63921 /* Exception.swift in Sources */,
 				63CDAB2E1DD9D49B00B63921 /* Event.swift in Sources */,
 				63CDAB291DD9D48800B63921 /* Sentry+Error.swift in Sources */,

--- a/SentrySwiftTests/SentrySwiftBreadcrumbTests.swift
+++ b/SentrySwiftTests/SentrySwiftBreadcrumbTests.swift
@@ -50,7 +50,7 @@ class SentrySwiftBreadcrumbTests: XCTestCase {
         let largeCrumb = Breadcrumb(category: "category", timestamp: date, message: "b", level: .Error, data: nil, url: "url2", method: "test", statusCode: 3, reason: "yay")
         let largeData = largeCrumb.serialized["data"] as! Dictionary<String, AnyType>
         XCTAssertEqual(largeData["url"] as? String, "url2")
-        XCTAssertEqual(largeData["reason"] as! String, "yay")
+        XCTAssertEqual(largeData["reason"] as? String, "yay")
         
         let smallBreadcrumb = Breadcrumb(category: "test", to: "tooo")
         let smallData = smallBreadcrumb.serialized["data"] as! Dictionary<String, String>

--- a/SentrySwiftTests/SentrySwiftTests.swift
+++ b/SentrySwiftTests/SentrySwiftTests.swift
@@ -587,7 +587,7 @@ class SentrySwiftTests: XCTestCase {
     #endif
     
     func testNoValidJSON() {
-        XCTAssertNil(Event.build("Alarm is too far in future") {
+        XCTAssertNotNil(Event.build("Alarm is too far in future") {
                 $0.level = .Warning
                 $0.extra = [
                     "Alarm ID": "12",
@@ -595,7 +595,7 @@ class SentrySwiftTests: XCTestCase {
                     "Local Query Time" : NSDate(),
                     "Local Current Time" : "123",
                     "Seconds Since Query" : "123123",
-                    "Seconds to arrival" : 123.1
+                    "Seconds to arrival" : 123.1,
                 ]
             }.serialized["extra"])
         
@@ -607,7 +607,7 @@ class SentrySwiftTests: XCTestCase {
                 "Local Query Time" : "asda",
                 "Local Current Time" : "123",
                 "Seconds Since Query" : "123123",
-                "Seconds to arrival" : 123.1
+                "Seconds to arrival" : 123.1,
             ]
             }.serialized["extra"])
         
@@ -619,7 +619,7 @@ class SentrySwiftTests: XCTestCase {
                 "Local Query Time" : "asda",
                 "Local Current Time" : "123",
                 "Seconds Since Query" : "123123",
-                "Seconds to arrival" : "123.1"
+                "Seconds to arrival" : "123.1",
             ]
             }.serialized["tags"])
     }
@@ -639,6 +639,25 @@ class SentrySwiftTests: XCTestCase {
         client.saveEvent(event)
         XCTAssertEqual(client.savedEvents().count, 0)
         XCTAssertEqual(client.savedEvents(since: (Date().timeIntervalSince1970 + 100)).count, 1)
+    }
+    
+    func testSanitation() {
+        let url: NSURL! = NSURL(string: "http://getsentry.io")
+        let error = NSError(domain: "domain", code: -1, userInfo: nil)
+        
+        #if swift(>=3.0)
+        let boolNumber = NSNumber(value: true)
+        #else
+        let boolNumber = NSNumber(bool: false)
+        #endif
+        
+        let array = ["string", url, boolNumber, NSDate(), error] as [AnyType]
+        
+        XCTAssert(JSONSerialization.isValidJSONObject(sanitize(array)))
+    
+        let event = Event.build("message") { _ in }
+        let dict: [String: AnyType] = ["key": array, "customObject": event]
+        XCTAssert(JSONSerialization.isValidJSONObject(sanitize(dict)))
     }
     
     #if swift(>=3.0)

--- a/Sources/Breadcrumb.swift
+++ b/Sources/Breadcrumb.swift
@@ -27,7 +27,7 @@ import Foundation
         self.timestamp = timestamp
         self.message = message
         self.type = type
-        self.data = data ?? [:]
+        self.data = (sanitize(data ?? [:]) as? [String: AnyType]) ?? [:]
         self.level = level
         
         super.init()

--- a/Sources/CrashReportConverter.swift
+++ b/Sources/CrashReportConverter.swift
@@ -69,7 +69,7 @@ internal final class CrashReportConverter {
             $0.level = .Fatal
             $0.timestamp = timestamp
             $0.tags = userInfo.tags ?? [:]
-            $0.extra = userInfo.extra ?? [:]
+            $0.extra = (sanitize(userInfo.extra ?? [:]) as? [String: AnyType]) ?? [:]
             $0.user = userInfo.user
             $0.breadcrumbsSerialized = userInfo.breadcrumbsSerialized
             $0.releaseVersion = userInfo.releaseVersion
@@ -86,7 +86,7 @@ internal final class CrashReportConverter {
     private static func parseUserInfo(_ userInfo: CrashDictionary?) -> UserInfo {
         return (
             userInfo?[keyEventTags] as? EventTags,
-            userInfo?[keyEventExtra] as? EventExtra,
+            sanitize(userInfo?[keyEventExtra] ?? [:]) as? EventExtra,
             User(dictionary: userInfo?[keyUser] as? [String: AnyObject]),
             userInfo?[keyBreadcrumbsSerialized] as? BreadcrumbStore.SerializedType,
             userInfo?[keyReleaseVersion] as? String,

--- a/Sources/Dictionary+Extras.swift
+++ b/Sources/Dictionary+Extras.swift
@@ -2,13 +2,31 @@
 //  Dictionary+Extras.swift
 //  SentrySwift
 //
-//  Created by David Chavez on 25/05/16.
+//  Created by David Chavez on 5/25/16.
 //
 //
 
 import Foundation
 
 extension Dictionary {
+    /// Returns a dictionary containing the results of mapping the given closure
+    /// over the dictionary's values.
+    ///
+    /// - Parameter transform: A mapping closure. `transform` accepts a
+    ///   value of this dictionary as its parameter and returns a transformed
+    ///   value of the same or of a different type.
+    /// - Returns: A dictionary containing the transformed values of this
+    ///   dictionary.
+    internal func map<T>(_ transform: (Value) throws -> T) rethrows -> [Key: T] {
+        var accum = [Key: T](minimumCapacity: self.count)
+        
+        for (key, value) in self {
+            accum[key] = try transform(value)
+        }
+        
+        return accum
+    }
+    
     internal mutating func unionInPlace(_ dictionary: Dictionary) {
         dictionary.forEach { self.updateValue(self[$0] ?? $1, forKey: $0) }
     }

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -129,9 +129,9 @@ public typealias EventFingerprint = [String]
         self.serverName = serverName
         self.releaseVersion = release
         self.buildNumber = buildNumber
-        self.tags = tags
+        self.tags = (sanitize(tags) as? EventTags) ?? [:]
         self.modules = modules
-        self.extra = extra
+        self.extra = (sanitize(extra) as? EventExtra) ?? [:]
         self.fingerprint = fingerprint
         
         // Optional Interfaces
@@ -189,17 +189,8 @@ extension Event: EventSerializable {
         attributes.append(("modules", modules))
         attributes.append(("fingerprint", fingerprint))
         
-        if JSONSerialization.isValidJSONObject(tags) {
-            attributes.append(("tags", tags))
-        } else if !tags.isEmpty {
-            Log.Error.log("event.tags is no valid json object, discarding it -> Check NSJSONSerialization.isValidJSONObject")
-        }
-        
-        if JSONSerialization.isValidJSONObject(extra) {
-            attributes.append(("extra", extra))
-        } else if !extra.isEmpty {
-            Log.Error.log("event.extra is no valid json object, discarding it -> Check NSJSONSerialization.isValidJSONObject")
-        }
+        attributes.append(("tags", tags))
+        attributes.append(("extra", extra))
         
         // Interfaces
         attributes.append(("user", user?.serialized))

--- a/Sources/Functions.swift
+++ b/Sources/Functions.swift
@@ -1,0 +1,51 @@
+//
+//  Functions.swift
+//  SentrySwift
+//
+//  Created by David Chavez on 1/27/17.
+//
+//
+
+import Foundation
+
+/// Sanitizes an object into a representation that can be
+/// validly converted to JSON data using JSONSerialization.
+///
+/// - Parameter object: the object to sanitize.
+/// - Returns: The nearest corellated object that can be converted to JSON. Defaults to string representation.
+/// The force unwrap is there to circumvent a bug in swiftc dealing with optionals and default cases..
+func sanitize(_ object: AnyType) -> AnyType {
+    switch object {
+    case let v as [AnyType]:
+        return v.map(sanitize)
+    case let v as [String: AnyType]:
+        return v.map(sanitize)
+    case let v as String:
+        return v as String
+    case let v as URL:
+        let url: String! = v.absoluteString
+        return url
+    case let v as NSNull:
+        return v
+    case let v as NSNumber:
+        if v.isBool {
+            return v as Bool
+        } else {
+            return v
+        }
+    case let v as NSError:
+        #if swift(>=3.0)
+            let userInfo = sanitize(v.userInfo)
+        #else
+            let userInfo = (sanitize(v.userInfo) as? [NSObject: AnyObject]) ?? [:]
+        #endif
+        
+        return [
+            "domain": v.domain,
+            "code": v.code,
+            "user_info": userInfo
+        ]
+    default:
+        return "\(object)"
+    }
+}

--- a/Sources/KSCrashHandler.swift
+++ b/Sources/KSCrashHandler.swift
@@ -101,7 +101,7 @@ internal final class KSCrashHandler: CrashHandler {
     private func updateUserInfo() {
         var userInfo = CrashDictionary()
         userInfo[keyEventTags] = tags
-        userInfo[keyEventExtra] = extra
+        userInfo[keyEventExtra] = sanitize(extra)
         userInfo[keyReleaseVersion] = releaseVersion
         userInfo[keyBuildNumber] = buildNumber
         

--- a/Sources/NSNumber+Extras.swift
+++ b/Sources/NSNumber+Extras.swift
@@ -1,0 +1,19 @@
+//
+//  NSNumber+Extras.swift
+//  SentrySwift
+//
+//  Created by David Chavez on 1/27/17.
+//
+//
+
+import Foundation
+
+extension NSNumber {
+    var isBool: Bool {
+        #if swift(>=3.0)
+        return type(of: self) == type(of: NSNumber(value: true))
+        #else
+        return CFBooleanGetTypeID() == CFGetTypeID(self)
+        #endif
+    }
+}

--- a/Sources/Sentry.swift
+++ b/Sources/Sentry.swift
@@ -146,8 +146,15 @@ internal enum SentryError: Error {
     public var tags: EventTags = [:] {
         didSet { crashHandler?.tags = tags }
     }
-    public var extra: EventExtra = [:] {
-        didSet { crashHandler?.extra = extra }
+    
+    private var _extra: EventExtra = [:] {
+        didSet { crashHandler?.extra = _extra }
+    }
+    public var extra: EventExtra {
+        get { return _extra }
+        set {
+            _extra = (sanitize(newValue) as? EventExtra) ?? [:]
+        }
     }
     public var user: User? = nil {
         didSet { crashHandler?.user = user }

--- a/Sources/User.swift
+++ b/Sources/User.swift
@@ -24,7 +24,7 @@ import Foundation
         self.userID = userID
         self.email = email
         self.username = username
-        self.extra = extra
+        self.extra = (sanitize(extra) as? [String: AnyType]) ?? [:]
 
         super.init()
     }


### PR DESCRIPTION
This will stop crashes that occur when you pass in keys that cannot be serializable into JSON. The current approach that I implemented a while back discarded the whole dictionary if it wasn't serializable. This approach will always serialize one way or another but will mostly try to do it correctly and gives us control on serializing particular types like `NSError`.